### PR TITLE
Bump  to version 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and to the [CHANGELOG recommendations](http://keepachangelog.com/).
 ## [Unreleased]
 
 
+## [0.3.3] - 2017-04-26
+
+### Added
+
+### Fixed
+- Fix admin translation
+- Fix duplicate booking options in admin
+- Fix similar listings back link
+- Fix design related change on manual translations fields 
+- Fix user image order in listing result
+- Fix Jquery CDN fallback
+- Fix duplicate listing dashboard forms name (to display them into Web Profiler)
+
+
+### Changed
+- Change listing availabilities route translation
+- Change doc
+- Remove arrows in user language select list
+- Allow all countries in listing deposit
+- Remove SBO characteristics description requirement
+- Do not display bill link in asker payments if asker fees are 0
+- Add error icon in translation tabs in case of error
+- Add Google API account creation explanation into README
+- Set disabled property to true in UserAdmin for Mangopay related fields
+- Set disabled property to true in ReviewAdmin for almost review fields
+
+### Deprecated
+
+
+
 ## [0.3.2] - 2017-01-25
 
 ### Added

--- a/app/Resources/translations/SonataAdminBundle.en.xliff
+++ b/app/Resources/translations/SonataAdminBundle.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -79,6 +79,36 @@
             <trans-unit id="51d671e59c7bdd9c1a13d2b3395be43b17bdf587" resname="Booking List">
                 <source>Booking List</source>
                 <target>Booking List</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="1f643ae4bad3a1394217ddd547941435a144d0a6" resname="Booking Option Batch">
+                <source>Booking Option Batch</source>
+                <target state="new">Booking Option Batch</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="411d3814a82e843114e56f3f04bc2421116b966f" resname="Booking Option Create">
+                <source>Booking Option Create</source>
+                <target state="new">Booking Option Create</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="ba80fdfa2a64291dbf3ace85a5e9c9272dec2f32" resname="Booking Option Delete">
+                <source>Booking Option Delete</source>
+                <target state="new">Booking Option Delete</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="6321820dc6e86f3c531efaeffdea043fa694088f" resname="Booking Option Edit">
+                <source>Booking Option Edit</source>
+                <target state="new">Booking Option Edit</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="b1d43a2128ec5443ea002f9e2e2775e285819893" resname="Booking Option List">
+                <source>Booking Option List</source>
+                <target state="new">Booking Option List</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="1f45a3b6bd49a162699af19cd48cdb6634d67fae" resname="Booking Option Update">
+                <source>Booking Option Update</source>
+                <target state="new">Booking Option Update</target>
                 <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7c820ebf5f4efe82a5a35ea714ac33082969d94c" resname="Booking Payin Refund Batch">
@@ -362,6 +392,11 @@
                 <target>Mangopay Transfer Id</target>
                 <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="a95e85aed56318093b024674e217cae0bd30241d" resname="Max">
+                <source>Max</source>
+                <target state="new">Max</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="68f4145fee7dde76afceb910165924ad14cf0d00" resname="Message">
                 <source>Message</source>
                 <target>Message</target>
@@ -402,10 +437,20 @@
                 <target>Messages</target>
                 <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="7eb0cee888ab55b559592d38eec027e9118d7d35" resname="Min">
+                <source>Min</source>
+                <target state="new">Min</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="709a23220f2c3d64d1e1d6d18c4d5280f8d82fca" resname="Name">
                 <source>Name</source>
                 <target state="new">Name</target>
                 <jms:reference-file>admin-bundle/Show/ShowMapper.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="6bf5da9c080bee3a8142586c412aa39971137eee" resname="Options">
+                <source>Options</source>
+                <target state="new">Options</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="636fe73cb2fc2d422175526ee35832ac8d16acb6" resname="Page Batch">
                 <source>Page Batch</source>
@@ -466,6 +511,16 @@
                 <source>Parameter Update</source>
                 <target state="new">Parameter Update</target>
                 <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="3e8248e32edfca0c629622b5b669c2d9ce4d0917" resname="Price">
+                <source>Price</source>
+                <target state="new">Price</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="44f6af6945544c0bab016a9160df6abb0cefcb60" resname="Quantity">
+                <source>Quantity</source>
+                <target state="new">Quantity</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6437b7bf655854909262d5f53fbe3bc7a6665b48" resname="Rating">
                 <source>Rating</source>
@@ -583,6 +638,36 @@
                 <target state="new">Value</target>
                 <jms:reference-file>admin-bundle/Show/ShowMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="aeea42e02877a2343b111ccab6e47834fef672bc" resname="Voucher Batch">
+                <source>Voucher Batch</source>
+                <target state="new">Voucher Batch</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="8293ec0ddec3a4d0fb9e045b0fc4b5ed9368b2b1" resname="Voucher Create">
+                <source>Voucher Create</source>
+                <target state="new">Voucher Create</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="2ae694dd29aa5f0156e8fb8544295060c6e34125" resname="Voucher Delete">
+                <source>Voucher Delete</source>
+                <target state="new">Voucher Delete</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="363ab898d6064cbab8b103c167c0da2dade16212" resname="Voucher Edit">
+                <source>Voucher Edit</source>
+                <target state="new">Voucher Edit</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="41ac4e5278ebbb8e6905200360b5c55fdbac0de1" resname="Voucher List">
+                <source>Voucher List</source>
+                <target state="new">Voucher List</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="feaf9231e300caa4cb887418f58b8a763ba6664b" resname="Voucher Update">
+                <source>Voucher Update</source>
+                <target state="new">Voucher Update</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="36522f9fece5a8cb38f5e17dcb432bb9f824ef9d" resname="Wire Reference">
                 <source>Wire Reference</source>
                 <target>Wire Reference</target>
@@ -639,12 +724,12 @@
             <trans-unit id="90049ba00652c96262c1f87f11b0d20c55481b0a" resname="admin.booking.amount_max.label">
                 <source>admin.booking.amount_max.label</source>
                 <target>Amount Maximum</target>
-                <jms:reference-file line="510">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="493">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7d3dacc817c3e563c3b13d5b1117926c5b40193e" resname="admin.booking.amount_min.label">
                 <source>admin.booking.amount_min.label</source>
                 <target>Amount Minimum</target>
-                <jms:reference-file line="495">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="478">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9151eeee10fc46946e6e92538922d7d7af65c473" resname="admin.booking.amount_options.title">
                 <source>admin.booking.amount_options.title</source>
@@ -655,7 +740,7 @@
                 <source>admin.booking.amount_to_pay_by_asker.label</source>
                 <target>Amount to pay / payed by asker</target>
                 <jms:reference-file line="161">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="622">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="605">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f0db41b03a7382942b9997e849402994e0582d6" resname="admin.booking.amount_to_pay_to_offerer.label">
                 <source>admin.booking.amount_to_pay_to_offerer.label</source>
@@ -672,8 +757,8 @@
                 <source>admin.booking.asker.label</source>
                 <target>Asker</target>
                 <jms:reference-file line="77">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="426">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="601">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="409">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="584">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="60">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="aa6f071724745deceb7a6aa19fd81018e76f9454" resname="admin.booking.canceled_asker_booking_at.label">
@@ -685,7 +770,7 @@
                 <source>admin.booking.code_voucher.label</source>
                 <target>Voucher code</target>
                 <jms:reference-file line="132">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="519">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="502">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="156">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="de31157454649204b5dbcf4d1c482d2cb3fd0e22" resname="admin.booking.created_at.label">
@@ -708,7 +793,7 @@
                 <source>admin.booking.end.label</source>
                 <target>Booking end day</target>
                 <jms:reference-file line="237">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="637">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="620">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="428">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="255">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -716,13 +801,13 @@
                 <source>admin.booking.end_time.label</source>
                 <target>Booking end time</target>
                 <jms:reference-file line="256">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="655">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="638">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="d52c84a7339da98d742e115a570be975ce5a8b03" resname="admin.booking.expire_at.label">
                 <source>admin.booking.expire_at.label</source>
                 <target>Expire At</target>
-                <jms:reference-file line="437">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="666">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="420">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="649">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7dcb7d17e625f1c12af3ea0211f208cd93601299" resname="admin.booking.label">
                 <source>admin.booking.label</source>
@@ -733,28 +818,28 @@
             <trans-unit id="c3309065c21b8919c1d444c558db153aaeec1df9" resname="admin.booking.listing_id.label">
                 <source>admin.booking.listing_id.label</source>
                 <target>Listing Id</target>
-                <jms:reference-file line="416">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="578">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="399">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="561">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="b9fbd56cf7483648157bf7df9dcdb57a523c73ef" resname="admin.booking.listing_title.label">
                 <source>admin.booking.listing_title.label</source>
                 <target>Listing</target>
-                <jms:reference-file line="421">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="404">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="dedf7f641d03fdd866d282cdc7f459e611fd448f" resname="admin.booking.mangopay_card_id.label">
                 <source>admin.booking.mangopay_card_id.label</source>
                 <target>Mangopay Card ID</target>
-                <jms:reference-file line="374">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="357">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f74e199b35905fa0c2ad252466831e19094846d" resname="admin.booking.mangopay_card_pre_auth_id.label">
                 <source>admin.booking.mangopay_card_pre_auth_id.label</source>
                 <target>Mangopay Card Pre Auth ID</target>
-                <jms:reference-file line="382">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="365">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6144488021b5702f890e0a4b9bcd25a1fbf42d14" resname="admin.booking.mangopay_payin_pre_auth_id.label">
                 <source>admin.booking.mangopay_payin_pre_auth_id.label</source>
                 <target>Mangopay Payin Pre Auth ID</target>
-                <jms:reference-file line="390">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="373">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="843f66b7c19c823a511961d119f4c831aba22f1b" resname="admin.booking.new_booking_at.label">
                 <source>admin.booking.new_booking_at.label</source>
@@ -765,8 +850,8 @@
                 <source>admin.booking.offerer.label</source>
                 <target>Offerer</target>
                 <jms:reference-file line="85">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="431">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="608">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="414">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="591">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="79">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="345">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="406">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -792,7 +877,7 @@
                 <source>admin.booking.start.label</source>
                 <target>Booking start day</target>
                 <jms:reference-file line="229">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="629">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="612">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="420">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="247">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -800,15 +885,15 @@
                 <source>admin.booking.start_time.label</source>
                 <target>Booking start time</target>
                 <jms:reference-file line="248">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="648">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="631">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="2842dd817f166672262625e977a646d0e2fa8334" resname="admin.booking.status.label">
                 <source>admin.booking.status.label</source>
                 <target>Status</target>
                 <jms:reference-file line="179">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="181">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="408">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="585">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="391">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="568">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="95">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="188">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="189">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -828,7 +913,7 @@
                 <source>admin.booking.updated_at.label</source>
                 <target>Updated At</target>
                 <jms:reference-file line="307">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="464">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="447">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="216">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="114">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -836,7 +921,7 @@
                 <source>admin.booking.validated.label</source>
                 <target>Validated</target>
                 <jms:reference-file line="202">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="594">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="577">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="f169ff06a484d036641cf596213b6509bc1a3c48" resname="admin.booking_bank_wire.amount.label">
                 <source>admin.booking_bank_wire.amount.label</source>
@@ -1051,7 +1136,7 @@
                 <source>admin.listing.label</source>
                 <target>Listing</target>
                 <jms:reference-file line="94">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="615">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="598">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="413">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="240">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>

--- a/app/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/app/Resources/translations/SonataAdminBundle.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -79,6 +79,36 @@
             <trans-unit id="51d671e59c7bdd9c1a13d2b3395be43b17bdf587" resname="Booking List">
                 <source>Booking List</source>
                 <target>Réservations</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="1f643ae4bad3a1394217ddd547941435a144d0a6" resname="Booking Option Batch">
+                <source>Booking Option Batch</source>
+                <target state="new">Booking Option Batch</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="411d3814a82e843114e56f3f04bc2421116b966f" resname="Booking Option Create">
+                <source>Booking Option Create</source>
+                <target state="new">Booking Option Create</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="ba80fdfa2a64291dbf3ace85a5e9c9272dec2f32" resname="Booking Option Delete">
+                <source>Booking Option Delete</source>
+                <target state="new">Booking Option Delete</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="6321820dc6e86f3c531efaeffdea043fa694088f" resname="Booking Option Edit">
+                <source>Booking Option Edit</source>
+                <target state="new">Booking Option Edit</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="b1d43a2128ec5443ea002f9e2e2775e285819893" resname="Booking Option List">
+                <source>Booking Option List</source>
+                <target state="new">Booking Option List</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="1f45a3b6bd49a162699af19cd48cdb6634d67fae" resname="Booking Option Update">
+                <source>Booking Option Update</source>
+                <target state="new">Booking Option Update</target>
                 <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7c820ebf5f4efe82a5a35ea714ac33082969d94c" resname="Booking Payin Refund Batch">
@@ -362,6 +392,11 @@
                 <target>Mangopay Transfer Id</target>
                 <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="a95e85aed56318093b024674e217cae0bd30241d" resname="Max">
+                <source>Max</source>
+                <target state="new">Max</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="68f4145fee7dde76afceb910165924ad14cf0d00" resname="Message">
                 <source>Message</source>
                 <target>Message</target>
@@ -402,10 +437,20 @@
                 <target>Messages</target>
                 <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="7eb0cee888ab55b559592d38eec027e9118d7d35" resname="Min">
+                <source>Min</source>
+                <target state="new">Min</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="709a23220f2c3d64d1e1d6d18c4d5280f8d82fca" resname="Name">
                 <source>Name</source>
                 <target>Name</target>
                 <jms:reference-file>admin-bundle/Show/ShowMapper.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="6bf5da9c080bee3a8142586c412aa39971137eee" resname="Options">
+                <source>Options</source>
+                <target state="new">Options</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="636fe73cb2fc2d422175526ee35832ac8d16acb6" resname="Page Batch">
                 <source>Page Batch</source>
@@ -466,6 +511,16 @@
                 <source>Parameter Update</source>
                 <target>Parameter Update</target>
                 <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="3e8248e32edfca0c629622b5b669c2d9ce4d0917" resname="Price">
+                <source>Price</source>
+                <target state="new">Price</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="44f6af6945544c0bab016a9160df6abb0cefcb60" resname="Quantity">
+                <source>Quantity</source>
+                <target state="new">Quantity</target>
+                <jms:reference-file>admin-bundle/Form/FormMapper.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6437b7bf655854909262d5f53fbe3bc7a6665b48" resname="Rating">
                 <source>Rating</source>
@@ -583,6 +638,36 @@
                 <target>Value</target>
                 <jms:reference-file>admin-bundle/Show/ShowMapper.php</jms:reference-file>
             </trans-unit>
+            <trans-unit id="aeea42e02877a2343b111ccab6e47834fef672bc" resname="Voucher Batch">
+                <source>Voucher Batch</source>
+                <target state="new">Code promotionnel Batch</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="8293ec0ddec3a4d0fb9e045b0fc4b5ed9368b2b1" resname="Voucher Create">
+                <source>Voucher Create</source>
+                <target state="new">Code promotionnel Edition Création</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="2ae694dd29aa5f0156e8fb8544295060c6e34125" resname="Voucher Delete">
+                <source>Voucher Delete</source>
+                <target state="new">Code promotionnel Supression</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="363ab898d6064cbab8b103c167c0da2dade16212" resname="Voucher Edit">
+                <source>Voucher Edit</source>
+                <target state="new">Code promotionnel Edition</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="41ac4e5278ebbb8e6905200360b5c55fdbac0de1" resname="Voucher List">
+                <source>Voucher List</source>
+                <target state="new">Codes promotionnels</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
+            <trans-unit id="feaf9231e300caa4cb887418f58b8a763ba6664b" resname="Voucher Update">
+                <source>Voucher Update</source>
+                <target state="new">Code promotionnel Modification</target>
+                <jms:reference-file>admin-bundle/Admin/Admin.php</jms:reference-file>
+            </trans-unit>
             <trans-unit id="36522f9fece5a8cb38f5e17dcb432bb9f824ef9d" resname="Wire Reference">
                 <source>Wire Reference</source>
                 <target>Wire Reference</target>
@@ -639,12 +724,12 @@
             <trans-unit id="90049ba00652c96262c1f87f11b0d20c55481b0a" resname="admin.booking.amount_max.label">
                 <source>admin.booking.amount_max.label</source>
                 <target>Montant max</target>
-                <jms:reference-file line="510">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="493">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7d3dacc817c3e563c3b13d5b1117926c5b40193e" resname="admin.booking.amount_min.label">
                 <source>admin.booking.amount_min.label</source>
                 <target>Montant min</target>
-                <jms:reference-file line="495">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="478">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9151eeee10fc46946e6e92538922d7d7af65c473" resname="admin.booking.amount_options.title">
                 <source>admin.booking.amount_options.title</source>
@@ -655,7 +740,7 @@
                 <source>admin.booking.amount_to_pay_by_asker.label</source>
                 <target>Montant à payer / payé par le demandeur</target>
                 <jms:reference-file line="161">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="622">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="605">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f0db41b03a7382942b9997e849402994e0582d6" resname="admin.booking.amount_to_pay_to_offerer.label">
                 <source>admin.booking.amount_to_pay_to_offerer.label</source>
@@ -672,8 +757,8 @@
                 <source>admin.booking.asker.label</source>
                 <target>Demandeur</target>
                 <jms:reference-file line="77">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="426">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="601">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="409">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="584">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="60">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="aa6f071724745deceb7a6aa19fd81018e76f9454" resname="admin.booking.canceled_asker_booking_at.label">
@@ -685,7 +770,7 @@
                 <source>admin.booking.code_voucher.label</source>
                 <target>Code promotionnel</target>
                 <jms:reference-file line="132">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="519">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="502">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="156">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="de31157454649204b5dbcf4d1c482d2cb3fd0e22" resname="admin.booking.created_at.label">
@@ -708,7 +793,7 @@
                 <source>admin.booking.end.label</source>
                 <target>Dernier jour de la réservation</target>
                 <jms:reference-file line="237">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="637">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="620">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="428">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="255">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -716,13 +801,13 @@
                 <source>admin.booking.end_time.label</source>
                 <target>Heure de fin</target>
                 <jms:reference-file line="256">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="655">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="638">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="d52c84a7339da98d742e115a570be975ce5a8b03" resname="admin.booking.expire_at.label">
                 <source>admin.booking.expire_at.label</source>
                 <target>Date d'expiration</target>
-                <jms:reference-file line="437">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="666">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="420">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="649">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7dcb7d17e625f1c12af3ea0211f208cd93601299" resname="admin.booking.label">
                 <source>admin.booking.label</source>
@@ -733,28 +818,28 @@
             <trans-unit id="c3309065c21b8919c1d444c558db153aaeec1df9" resname="admin.booking.listing_id.label">
                 <source>admin.booking.listing_id.label</source>
                 <target>Id Annonce</target>
-                <jms:reference-file line="416">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="578">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="399">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="561">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="b9fbd56cf7483648157bf7df9dcdb57a523c73ef" resname="admin.booking.listing_title.label">
                 <source>admin.booking.listing_title.label</source>
                 <target>Titre de l'annonce</target>
-                <jms:reference-file line="421">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="404">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="dedf7f641d03fdd866d282cdc7f459e611fd448f" resname="admin.booking.mangopay_card_id.label">
                 <source>admin.booking.mangopay_card_id.label</source>
                 <target>Mangopay Card ID</target>
-                <jms:reference-file line="374">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="357">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f74e199b35905fa0c2ad252466831e19094846d" resname="admin.booking.mangopay_card_pre_auth_id.label">
                 <source>admin.booking.mangopay_card_pre_auth_id.label</source>
                 <target>Mangopay Card Pre Auth ID</target>
-                <jms:reference-file line="382">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="365">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6144488021b5702f890e0a4b9bcd25a1fbf42d14" resname="admin.booking.mangopay_payin_pre_auth_id.label">
                 <source>admin.booking.mangopay_payin_pre_auth_id.label</source>
                 <target>Mangopay Payin Pre Auth ID</target>
-                <jms:reference-file line="390">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="373">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="843f66b7c19c823a511961d119f4c831aba22f1b" resname="admin.booking.new_booking_at.label">
                 <source>admin.booking.new_booking_at.label</source>
@@ -765,8 +850,8 @@
                 <source>admin.booking.offerer.label</source>
                 <target>Offreur</target>
                 <jms:reference-file line="85">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="431">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="608">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="414">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="591">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="79">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="345">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="406">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -792,7 +877,7 @@
                 <source>admin.booking.start.label</source>
                 <target>1er jour de la réservation</target>
                 <jms:reference-file line="229">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="629">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="612">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="420">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="247">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -800,15 +885,15 @@
                 <source>admin.booking.start_time.label</source>
                 <target>Heure de début</target>
                 <jms:reference-file line="248">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="648">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="631">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="2842dd817f166672262625e977a646d0e2fa8334" resname="admin.booking.status.label">
                 <source>admin.booking.status.label</source>
                 <target>Statut</target>
                 <jms:reference-file line="179">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="181">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="408">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="585">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="391">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="568">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="95">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="188">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="189">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -828,7 +913,7 @@
                 <source>admin.booking.updated_at.label</source>
                 <target>Mis à jour</target>
                 <jms:reference-file line="307">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="464">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="447">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="216">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="114">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -836,7 +921,7 @@
                 <source>admin.booking.validated.label</source>
                 <target>Validé</target>
                 <jms:reference-file line="202">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="594">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="577">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="f169ff06a484d036641cf596213b6509bc1a3c48" resname="admin.booking_bank_wire.amount.label">
                 <source>admin.booking_bank_wire.amount.label</source>
@@ -1051,7 +1136,7 @@
                 <source>admin.listing.label</source>
                 <target>Annonce</target>
                 <jms:reference-file line="94">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="615">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="598">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="413">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="240">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>

--- a/app/Resources/translations/SonataUserBundle.en.xliff
+++ b/app/Resources/translations/SonataUserBundle.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/SonataUserBundle.fr.xliff
+++ b/app/Resources/translations/SonataUserBundle.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico.en.xliff
+++ b/app/Resources/translations/cocorico.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico.fr.xliff
+++ b/app/Resources/translations/cocorico.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:39Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_admin_menu.fr.xliff
+++ b/app/Resources/translations/cocorico_admin_menu.fr.xliff
@@ -53,6 +53,10 @@
                 <source>Footers</source>
                 <target>Pieds de page</target>
             </trans-unit>
+            <trans-unit id="Vouchers">
+                <source>Vouchers</source>
+                <target>Codes promotionnels</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/app/Resources/translations/cocorico_booking.en.xliff
+++ b/app/Resources/translations/cocorico_booking.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -11,7 +11,7 @@
                 <target>Status</target>
                 <jms:reference-file line="179">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="181">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="408">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="391">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="95">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="188">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="189">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -29,20 +29,20 @@
             <trans-unit id="c963936b54415544e2b2c4f28c4590f12c0bfa09" resname="booking.amount.help">
                 <source>booking.amount.help</source>
                 <target>Amount help</target>
-                <jms:reference-file line="118">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="120">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="147">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="149">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="119">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="121">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="148">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="150">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="a7cc6a2d75bb2bae7a95a4b8f099e8a7d9e62d8c" resname="booking.amount.total:">
                 <source>booking.amount.total:</source>
                 <target>Total incl tax:</target>
-                <jms:reference-file line="142">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="143">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="8fa9fa3a66caba10eec67411f38571f93013efb0" resname="booking.amount:">
                 <source>booking.amount:</source>
                 <target>Amount excluding fees:</target>
-                <jms:reference-file line="109">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="110">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="22075545a9ac9feae48656294d7a1076e3104207" resname="booking.amount_total.help">
                 <source>booking.amount_total.help</source>
@@ -165,7 +165,7 @@
                 <source>booking.bill.title.vat</source>
                 <target>VAT</target>
                 <jms:reference-file line="99">views/Dashboard/layout_show_bill.html.twig</jms:reference-file>
-                <jms:reference-file line="155">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="156">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="b89b51b92e96cf733f4340a7a89bcd9c28af6b29" resname="booking.bill.user.address">
                 <source>booking.bill.user.address</source>
@@ -184,7 +184,7 @@
                 <jms:reference-file line="92">Dashboard/Booking/_booking_index.html.twig</jms:reference-file>
                 <jms:reference-file line="119">Dashboard/Booking/_booking_show.html.twig</jms:reference-file>
                 <jms:reference-file line="54">Frontend/Booking/form_booking_price.html.twig</jms:reference-file>
-                <jms:reference-file line="98">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="99">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="1f8b18d0d699e8cdef8ccc60f90ba5f21577e44c" resname="booking.edit.error">
                 <source>booking.edit.error</source>
@@ -213,13 +213,13 @@
             <trans-unit id="1fe5c2a60d90e8d61c5148504d6fc6524b147bbe" resname="booking.fees.amount:">
                 <source>booking.fees.amount:</source>
                 <target>Including fees:</target>
-                <jms:reference-file line="163">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="164">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="45f4286d5f0a88a711ab63b8d7e18b9517fd9c21" resname="booking.fees.help">
                 <source>booking.fees.help</source>
                 <target>Fees help</target>
-                <jms:reference-file line="165">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="167">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="166">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="168">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0ebee020ab091ca03d795dbe10632c32fb11f480" resname="booking.form.end">
                 <source>booking.form.end</source>
@@ -318,12 +318,12 @@
             <trans-unit id="c7de4f52f1bf3074e96c0f94b6fb806ad7c2e469" resname="booking.new.message.placeholder">
                 <source>booking.new.message.placeholder</source>
                 <target>Send a request message to the offerer</target>
-                <jms:reference-file line="198">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="199">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="083c618c0d6cea305c1e7472bcceb15434994011" resname="booking.new.provider.title">
                 <source>booking.new.provider.title</source>
                 <target>Say hello to your provider</target>
-                <jms:reference-file line="243">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="244">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="28b9e3c63b01f9d312668d113cd7eb5c04157a3c" resname="booking.new.self_booking.error">
                 <source>booking.new.self_booking.error</source>
@@ -339,7 +339,7 @@
                 <source>booking.new.tac.link</source>
                 <target>the terms and conditions</target>
                 <jms:reference-file line="136">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="220">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="221">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="ecc3fa0ac15c5eb33b33f1f1be3eeebd95d9ffcc" resname="booking.new.unknown.error">
                 <source>booking.new.unknown.error</source>
@@ -351,7 +351,7 @@
             <trans-unit id="b370314c697defb1d7393abebaf775f49845880b" resname="booking.new.validation.submit">
                 <source>booking.new.validation.submit</source>
                 <target>Validate booking</target>
-                <jms:reference-file line="225">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="226">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0462988b55dd0888cce21c33dc9ad8ecff7e38c6" resname="booking.new.voucher.success">
                 <source>booking.new.voucher.success</source>
@@ -412,7 +412,7 @@
             <trans-unit id="8d81b919f32669b6c9f8cd9be5b45f48d7463736" resname="booking.secured_message">
                 <source>booking.secured_message</source>
                 <target>This page is secured by AES 256 bit encryption</target>
-                <jms:reference-file line="66">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="67">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="3ea7b9c6dd9eb1fa552b8b32f97421f386d40dee" resname="booking.show.address.title">
                 <source>booking.show.address.title</source>
@@ -520,7 +520,7 @@
             <trans-unit id="7ada668f56cd492d11deebbaaea62c263b8b5cdd" resname="booking.total_amount">
                 <source>booking.total_amount</source>
                 <target>Total amount</target>
-                <jms:reference-file line="136">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="137">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="9fa474d1bd7c96c0e054f6d8e275e48455bd1573" resname="booking.voucher.address">
                 <source>booking.voucher.address</source>
@@ -642,13 +642,13 @@
             <trans-unit id="40cdccf226cbb6688a25713f9628b0f3e7959bb4" resname="listing.show.rules:">
                 <source>listing.show.rules:</source>
                 <target>Rules</target>
-                <jms:reference-file line="286">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="287">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="c7a4298347ed905bf82c406276876396d2b49a12" resname="nav.tac.slug">
                 <source>nav.tac.slug</source>
                 <target>terms-of-use</target>
                 <jms:reference-file line="134">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="218">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="219">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="cdf7e925f5746741c316f5fbcf39ad0dfca90775" resname="results">
                 <source>results</source>

--- a/app/Resources/translations/cocorico_booking.fr.xliff
+++ b/app/Resources/translations/cocorico_booking.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -11,7 +11,7 @@
                 <target>Tous</target>
                 <jms:reference-file line="179">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="181">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="408">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="391">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="95">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="188">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="189">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -29,20 +29,20 @@
             <trans-unit id="c963936b54415544e2b2c4f28c4590f12c0bfa09" resname="booking.amount.help">
                 <source>booking.amount.help</source>
                 <target>booking.amount.help</target>
-                <jms:reference-file line="118">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="120">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="147">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="149">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="119">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="121">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="148">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="150">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="a7cc6a2d75bb2bae7a95a4b8f099e8a7d9e62d8c" resname="booking.amount.total:">
                 <source>booking.amount.total:</source>
                 <target>Total TTC :</target>
-                <jms:reference-file line="142">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="143">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="8fa9fa3a66caba10eec67411f38571f93013efb0" resname="booking.amount:">
                 <source>booking.amount:</source>
                 <target>Montant de la réservation hors commissions :</target>
-                <jms:reference-file line="109">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="110">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="22075545a9ac9feae48656294d7a1076e3104207" resname="booking.amount_total.help">
                 <source>booking.amount_total.help</source>
@@ -166,7 +166,7 @@
                 <source>booking.bill.title.vat</source>
                 <target>TVA</target>
                 <jms:reference-file line="99">views/Dashboard/layout_show_bill.html.twig</jms:reference-file>
-                <jms:reference-file line="155">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="156">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="b89b51b92e96cf733f4340a7a89bcd9c28af6b29" resname="booking.bill.user.address">
                 <source>booking.bill.user.address</source>
@@ -185,7 +185,7 @@
                 <jms:reference-file line="92">Dashboard/Booking/_booking_index.html.twig</jms:reference-file>
                 <jms:reference-file line="119">Dashboard/Booking/_booking_show.html.twig</jms:reference-file>
                 <jms:reference-file line="54">Frontend/Booking/form_booking_price.html.twig</jms:reference-file>
-                <jms:reference-file line="98">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="99">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="1f8b18d0d699e8cdef8ccc60f90ba5f21577e44c" resname="booking.edit.error">
                 <source>booking.edit.error</source>
@@ -214,13 +214,13 @@
             <trans-unit id="1fe5c2a60d90e8d61c5148504d6fc6524b147bbe" resname="booking.fees.amount:">
                 <source>booking.fees.amount:</source>
                 <target>Dont frais de service :</target>
-                <jms:reference-file line="163">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="164">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="45f4286d5f0a88a711ab63b8d7e18b9517fd9c21" resname="booking.fees.help">
                 <source>booking.fees.help</source>
                 <target>booking.fees.help</target>
-                <jms:reference-file line="165">Frontend/Booking/new.html.twig</jms:reference-file>
-                <jms:reference-file line="167">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="166">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="168">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0ebee020ab091ca03d795dbe10632c32fb11f480" resname="booking.form.end">
                 <source>booking.form.end</source>
@@ -319,12 +319,12 @@
             <trans-unit id="c7de4f52f1bf3074e96c0f94b6fb806ad7c2e469" resname="booking.new.message.placeholder">
                 <source>booking.new.message.placeholder</source>
                 <target>Rédiger votre message de demande à l'attention de l'offreur</target>
-                <jms:reference-file line="198">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="199">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="083c618c0d6cea305c1e7472bcceb15434994011" resname="booking.new.provider.title">
                 <source>booking.new.provider.title</source>
                 <target>Dites bonjour !</target>
-                <jms:reference-file line="243">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="244">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="28b9e3c63b01f9d312668d113cd7eb5c04157a3c" resname="booking.new.self_booking.error">
                 <source>booking.new.self_booking.error</source>
@@ -340,7 +340,7 @@
                 <source>booking.new.tac.link</source>
                 <target>les termes et conditions</target>
                 <jms:reference-file line="136">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="220">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="221">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="ecc3fa0ac15c5eb33b33f1f1be3eeebd95d9ffcc" resname="booking.new.unknown.error">
                 <source>booking.new.unknown.error</source>
@@ -352,7 +352,7 @@
             <trans-unit id="b370314c697defb1d7393abebaf775f49845880b" resname="booking.new.validation.submit">
                 <source>booking.new.validation.submit</source>
                 <target>Payer</target>
-                <jms:reference-file line="225">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="226">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0462988b55dd0888cce21c33dc9ad8ecff7e38c6" resname="booking.new.voucher.success">
                 <source>booking.new.voucher.success</source>
@@ -413,7 +413,7 @@
             <trans-unit id="8d81b919f32669b6c9f8cd9be5b45f48d7463736" resname="booking.secured_message">
                 <source>booking.secured_message</source>
                 <target>Cette page est sécurisée par le moyen d’un cryptage AES 256 bits.</target>
-                <jms:reference-file line="66">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="67">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="3ea7b9c6dd9eb1fa552b8b32f97421f386d40dee" resname="booking.show.address.title">
                 <source>booking.show.address.title</source>
@@ -521,7 +521,7 @@
             <trans-unit id="7ada668f56cd492d11deebbaaea62c263b8b5cdd" resname="booking.total_amount">
                 <source>booking.total_amount</source>
                 <target>Montant total de la réservation</target>
-                <jms:reference-file line="136">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="137">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="9fa474d1bd7c96c0e054f6d8e275e48455bd1573" resname="booking.voucher.address">
                 <source>booking.voucher.address</source>
@@ -643,13 +643,13 @@
             <trans-unit id="40cdccf226cbb6688a25713f9628b0f3e7959bb4" resname="listing.show.rules:">
                 <source>listing.show.rules:</source>
                 <target>Règles</target>
-                <jms:reference-file line="286">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="287">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="c7a4298347ed905bf82c406276876396d2b49a12" resname="nav.tac.slug">
                 <source>nav.tac.slug</source>
                 <target>conditions-generales-d-utilisation</target>
                 <jms:reference-file line="134">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="218">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="219">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="cdf7e925f5746741c316f5fbcf39ad0dfca90775" resname="results">
                 <source>results</source>

--- a/app/Resources/translations/cocorico_breadcrumbs.en.xliff
+++ b/app/Resources/translations/cocorico_breadcrumbs.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_breadcrumbs.fr.xliff
+++ b/app/Resources/translations/cocorico_breadcrumbs.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:39Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_contact.en.xliff
+++ b/app/Resources/translations/cocorico_contact.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_contact.fr.xliff
+++ b/app/Resources/translations/cocorico_contact.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_geo.en.xliff
+++ b/app/Resources/translations/cocorico_geo.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_geo.fr.xliff
+++ b/app/Resources/translations/cocorico_geo.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_listing.en.xliff
+++ b/app/Resources/translations/cocorico_listing.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -749,14 +749,14 @@
                 <source>listing.show.cancellation_policy:</source>
                 <target>Cancellation policy:</target>
                 <jms:reference-file line="111">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="278">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="279">Frontend/Booking/new.html.twig</jms:reference-file>
                 <jms:reference-file line="318">Frontend/Listing/show.html.twig</jms:reference-file>
                 <jms:reference-file line="239">Frontend/Profile/show.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0ae4b06ef673f71c7347ad8689eca40f8a56dd79" resname="listing.show.categories:">
                 <source>listing.show.categories:</source>
                 <target>Categories:</target>
-                <jms:reference-file line="266">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="267">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0a197cf0dd3b9370c948ecb4c6ae6a99f28460f3" resname="listing.show.characteristics">
                 <source>listing.show.characteristics</source>
@@ -802,7 +802,7 @@
             <trans-unit id="49ff4bce3e52dd086b802ffa369d62b7e99d537b" resname="listing.show.location:">
                 <source>listing.show.location:</source>
                 <target>Location:</target>
-                <jms:reference-file line="274">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="275">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="368a7d80b53cf610605714c046875ad7fd4d19b6" resname="listing.show.map">
                 <source>listing.show.map</source>

--- a/app/Resources/translations/cocorico_listing.fr.xliff
+++ b/app/Resources/translations/cocorico_listing.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -751,14 +751,14 @@
                 <source>listing.show.cancellation_policy:</source>
                 <target>Politique d'annulation :</target>
                 <jms:reference-file line="111">Dashboard/Booking/edit.html.twig</jms:reference-file>
-                <jms:reference-file line="278">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="279">Frontend/Booking/new.html.twig</jms:reference-file>
                 <jms:reference-file line="318">Frontend/Listing/show.html.twig</jms:reference-file>
                 <jms:reference-file line="239">Frontend/Profile/show.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0ae4b06ef673f71c7347ad8689eca40f8a56dd79" resname="listing.show.categories:">
                 <source>listing.show.categories:</source>
                 <target>Catégories</target>
-                <jms:reference-file line="266">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="267">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="0a197cf0dd3b9370c948ecb4c6ae6a99f28460f3" resname="listing.show.characteristics">
                 <source>listing.show.characteristics</source>
@@ -804,7 +804,7 @@
             <trans-unit id="49ff4bce3e52dd086b802ffa369d62b7e99d537b" resname="listing.show.location:">
                 <source>listing.show.location:</source>
                 <target>Lieu :</target>
-                <jms:reference-file line="274">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="275">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="368a7d80b53cf610605714c046875ad7fd4d19b6" resname="listing.show.map">
                 <source>listing.show.map</source>
@@ -911,7 +911,7 @@
             </trans-unit>
             <trans-unit id="12d03c7881be7801d0b91849e46681a9f542e691" resname="listing_duration.overlap">
                 <source>listing_duration.overlap</source>
-                <target>Lu durée maximum doit être supérieur à la durée minimum</target>
+                <target>La durée maximum doit être supérieur à la durée minimum</target>
             </trans-unit>
             <trans-unit id="dc67ba70167c19d6c2ed7c6ac4c5073f8edb163b" resname="listing_edit.form.cancellation_policy">
                 <source>listing_edit.form.cancellation_policy</source>
@@ -1146,7 +1146,7 @@
             </trans-unit>
             <trans-unit id="153da8e1965e2a08a0725a19818c5c6ab3b93fbc" resname="time_ranges.min {{ limit }}">
                 <source>time_ranges.min {{ limit }}</source>
-                <target><![CDATA[>Vous devez ajouter au moins {{ limit }} plage(s) horaire(s)]]></target>
+                <target>Vous devez ajouter au moins {{ limit }} plage(s) horaire(s)</target>
             </trans-unit>
             <trans-unit id="e136453317e18e2178a362d734beabb14670fadd" resname="time_ranges.overlap">
                 <source>time_ranges.overlap</source>

--- a/app/Resources/translations/cocorico_mail.en.xliff
+++ b/app/Resources/translations/cocorico_mail.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_mail.fr.xliff
+++ b/app/Resources/translations/cocorico_mail.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_message.en.xliff
+++ b/app/Resources/translations/cocorico_message.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_message.fr.xliff
+++ b/app/Resources/translations/cocorico_message.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_meta.en.xliff
+++ b/app/Resources/translations/cocorico_meta.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,12 +9,12 @@
             <trans-unit id="46fdda4a5d3126614388f58a8f228edfa57b2b51" resname="booking.new.meta_desc">
                 <source>booking.new.meta_desc</source>
                 <target>booking.new.meta_desc</target>
-                <jms:reference-file line="33">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="35">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="14b6b218dbec12074bce69744dee7aa0ddf72dc0" resname="booking.new.meta_title">
                 <source>booking.new.meta_title</source>
                 <target>booking.new.meta_title</target>
-                <jms:reference-file line="29">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="31">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="855475bb058132617c6e3b515401462f03154acc" resname="contact.meta_desc">
                 <source>contact.meta_desc</source>

--- a/app/Resources/translations/cocorico_meta.fr.xliff
+++ b/app/Resources/translations/cocorico_meta.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,12 +9,12 @@
             <trans-unit id="46fdda4a5d3126614388f58a8f228edfa57b2b51" resname="booking.new.meta_desc">
                 <source>booking.new.meta_desc</source>
                 <target>booking.new.meta_desc</target>
-                <jms:reference-file line="33">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="35">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="14b6b218dbec12074bce69744dee7aa0ddf72dc0" resname="booking.new.meta_title">
                 <source>booking.new.meta_title</source>
                 <target>booking.new.meta_title</target>
-                <jms:reference-file line="29">Frontend/Booking/new.html.twig</jms:reference-file>
+                <jms:reference-file line="31">Frontend/Booking/new.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="855475bb058132617c6e3b515401462f03154acc" resname="contact.meta_desc">
                 <source>contact.meta_desc</source>

--- a/app/Resources/translations/cocorico_review.en.xliff
+++ b/app/Resources/translations/cocorico_review.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_review.fr.xliff
+++ b/app/Resources/translations/cocorico_review.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -111,12 +111,12 @@
             </trans-unit>
             <trans-unit id="ead95da854790aade615a878757d1b5820670a6c" resname="review.comment.reviewed_user">
                 <source>review.comment.reviewed_user</source>
-                <target>Personne que vous avez noté</target>
+                <target>Personne que vous avez notée</target>
                 <jms:reference-file line="57">Dashboard/Review/_reviews.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="61e65ede52354892c7e595264d7b92731597e892" resname="review.comment.reviewer">
                 <source>review.comment.reviewer</source>
-                <target state="new">Personne qui vous a noté</target>
+                <target state="new">Personne qui vous a notée</target>
                 <jms:reference-file line="62">Dashboard/Review/_reviews.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="d2144bfb149404dfd4ad9eec9ccc2a7f2ff98100" resname="review.comment.start_date">

--- a/app/Resources/translations/cocorico_sms.en.xliff
+++ b/app/Resources/translations/cocorico_sms.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_sms.fr.xliff
+++ b/app/Resources/translations/cocorico_sms.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/cocorico_user.en.xliff
+++ b/app/Resources/translations/cocorico_user.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -283,7 +283,7 @@
             <trans-unit id="9741ffbcf8dbb31e1a2d32bd25cb0ccc5a6dea54" resname="profile.edit.submit">
                 <source>profile.edit.submit</source>
                 <target>Update</target>
-                <jms:reference-file line="162">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="168">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
                 <jms:reference-file line="176">Dashboard/Profile/edit_contact.html.twig</jms:reference-file>
                 <jms:reference-file line="213">Dashboard/Profile/edit_payment.html.twig</jms:reference-file>
             </trans-unit>
@@ -295,7 +295,7 @@
             <trans-unit id="45a41d2099651dbd7df02437427e3748ba96b07a" resname="profile.languages.add">
                 <source>profile.languages.add</source>
                 <target>Add</target>
-                <jms:reference-file line="82">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="86">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="53a4c93891d17fd3483b6f6ce77ae09c1ffed517" resname="profile.languages.title">
                 <source>profile.languages.title</source>
@@ -305,7 +305,7 @@
             <trans-unit id="b9f867fdb018c329dd0452a22e07224cf7cfb0d4" resname="profile.moreinfo.title">
                 <source>profile.moreinfo.title</source>
                 <target>Tell us about yourself</target>
-                <jms:reference-file line="109">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="113">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="1fa5b2873fe30be026b854f6a51503b86c6ac81a" resname="registration.back">
                 <source>registration.back</source>
@@ -554,7 +554,7 @@
             <trans-unit id="09d7893d52caa3806811a4a82fd75ad169413f84" resname="user.translate.button">
                 <source>user.translate.button</source>
                 <target>Translate</target>
-                <jms:reference-file line="152">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="158">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="b55451c1697d951ccdd55692e6318f807690f7f6" resname="user_images.max {{ max_images }}">
                 <source>user_images.max {{ max_images }}</source>

--- a/app/Resources/translations/cocorico_user.fr.xliff
+++ b/app/Resources/translations/cocorico_user.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -283,7 +283,7 @@
             <trans-unit id="9741ffbcf8dbb31e1a2d32bd25cb0ccc5a6dea54" resname="profile.edit.submit">
                 <source>profile.edit.submit</source>
                 <target>Mettre à jour</target>
-                <jms:reference-file line="162">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="168">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
                 <jms:reference-file line="176">Dashboard/Profile/edit_contact.html.twig</jms:reference-file>
                 <jms:reference-file line="213">Dashboard/Profile/edit_payment.html.twig</jms:reference-file>
             </trans-unit>
@@ -295,7 +295,7 @@
             <trans-unit id="45a41d2099651dbd7df02437427e3748ba96b07a" resname="profile.languages.add">
                 <source>profile.languages.add</source>
                 <target>Ajouter</target>
-                <jms:reference-file line="82">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="86">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="53a4c93891d17fd3483b6f6ce77ae09c1ffed517" resname="profile.languages.title">
                 <source>profile.languages.title</source>
@@ -305,7 +305,7 @@
             <trans-unit id="b9f867fdb018c329dd0452a22e07224cf7cfb0d4" resname="profile.moreinfo.title">
                 <source>profile.moreinfo.title</source>
                 <target>A propos de vous</target>
-                <jms:reference-file line="109">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="113">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="1fa5b2873fe30be026b854f6a51503b86c6ac81a" resname="registration.back">
                 <source>registration.back</source>
@@ -556,7 +556,7 @@
             <trans-unit id="09d7893d52caa3806811a4a82fd75ad169413f84" resname="user.translate.button">
                 <source>user.translate.button</source>
                 <target>Traduire</target>
-                <jms:reference-file line="152">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
+                <jms:reference-file line="158">Dashboard/Profile/edit_about_me.html.twig</jms:reference-file>
             </trans-unit>
             <trans-unit id="b55451c1697d951ccdd55692e6318f807690f7f6" resname="user_images.max {{ max_images }}">
                 <source>user_images.max {{ max_images }}</source>

--- a/app/Resources/translations/messages.en.xliff
+++ b/app/Resources/translations/messages.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,13 +9,13 @@
             <trans-unit id="8a681a2f041f4625cceacf20f0cf8ebf4248b5f1" resname="&lt;=">
                 <source><![CDATA[<=]]></source>
                 <target state="new"><![CDATA[<=]]></target>
-                <jms:reference-file line="507">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="490">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="322">CoreBundle/Admin/ListingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6c22e68f3b484db9779ac9e86488c2648313c410" resname="&gt;=">
                 <source><![CDATA[>=]]></source>
                 <target><![CDATA[>=]]></target>
-                <jms:reference-file line="492">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="475">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="307">CoreBundle/Admin/ListingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="4281c52d617278a34a14cf5faf9c6fb11df197a6" resname="Asker">
@@ -134,12 +134,12 @@
             <trans-unit id="90049ba00652c96262c1f87f11b0d20c55481b0a" resname="admin.booking.amount_max.label">
                 <source>admin.booking.amount_max.label</source>
                 <target>admin.booking.amount_max.label</target>
-                <jms:reference-file line="510">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="493">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7d3dacc817c3e563c3b13d5b1117926c5b40193e" resname="admin.booking.amount_min.label">
                 <source>admin.booking.amount_min.label</source>
                 <target>admin.booking.amount_min.label</target>
-                <jms:reference-file line="495">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="478">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9151eeee10fc46946e6e92538922d7d7af65c473" resname="admin.booking.amount_options.title">
                 <source>admin.booking.amount_options.title</source>
@@ -150,7 +150,7 @@
                 <source>admin.booking.amount_to_pay_by_asker.label</source>
                 <target>Amount to pay by asker</target>
                 <jms:reference-file line="161">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="622">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="605">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f0db41b03a7382942b9997e849402994e0582d6" resname="admin.booking.amount_to_pay_to_offerer.label">
                 <source>admin.booking.amount_to_pay_to_offerer.label</source>
@@ -167,8 +167,8 @@
                 <source>admin.booking.asker.label</source>
                 <target>Asker</target>
                 <jms:reference-file line="77">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="426">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="601">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="409">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="584">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="60">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="aa6f071724745deceb7a6aa19fd81018e76f9454" resname="admin.booking.canceled_asker_booking_at.label">
@@ -180,7 +180,7 @@
                 <source>admin.booking.code_voucher.label</source>
                 <target>admin.booking.code_voucher.label</target>
                 <jms:reference-file line="132">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="519">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="502">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="156">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="de31157454649204b5dbcf4d1c482d2cb3fd0e22" resname="admin.booking.created_at.label">
@@ -203,7 +203,7 @@
                 <source>admin.booking.end.label</source>
                 <target>Booking end date</target>
                 <jms:reference-file line="237">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="637">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="620">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="428">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="255">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -211,13 +211,13 @@
                 <source>admin.booking.end_time.label</source>
                 <target>Booking end time</target>
                 <jms:reference-file line="256">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="655">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="638">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="d52c84a7339da98d742e115a570be975ce5a8b03" resname="admin.booking.expire_at.label">
                 <source>admin.booking.expire_at.label</source>
                 <target>Expiration date</target>
-                <jms:reference-file line="437">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="666">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="420">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="649">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7dcb7d17e625f1c12af3ea0211f208cd93601299" resname="admin.booking.label">
                 <source>admin.booking.label</source>
@@ -228,28 +228,28 @@
             <trans-unit id="c3309065c21b8919c1d444c558db153aaeec1df9" resname="admin.booking.listing_id.label">
                 <source>admin.booking.listing_id.label</source>
                 <target>Listing ID</target>
-                <jms:reference-file line="416">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="578">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="399">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="561">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="b9fbd56cf7483648157bf7df9dcdb57a523c73ef" resname="admin.booking.listing_title.label">
                 <source>admin.booking.listing_title.label</source>
                 <target>Listing title</target>
-                <jms:reference-file line="421">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="404">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="dedf7f641d03fdd866d282cdc7f459e611fd448f" resname="admin.booking.mangopay_card_id.label">
                 <source>admin.booking.mangopay_card_id.label</source>
                 <target>admin.booking.mangopay_card_id.label</target>
-                <jms:reference-file line="374">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="357">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f74e199b35905fa0c2ad252466831e19094846d" resname="admin.booking.mangopay_card_pre_auth_id.label">
                 <source>admin.booking.mangopay_card_pre_auth_id.label</source>
                 <target>admin.booking.mangopay_card_pre_auth_id.label</target>
-                <jms:reference-file line="382">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="365">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6144488021b5702f890e0a4b9bcd25a1fbf42d14" resname="admin.booking.mangopay_payin_pre_auth_id.label">
                 <source>admin.booking.mangopay_payin_pre_auth_id.label</source>
                 <target>admin.booking.mangopay_payin_pre_auth_id.label</target>
-                <jms:reference-file line="390">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="373">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="843f66b7c19c823a511961d119f4c831aba22f1b" resname="admin.booking.new_booking_at.label">
                 <source>admin.booking.new_booking_at.label</source>
@@ -260,8 +260,8 @@
                 <source>admin.booking.offerer.label</source>
                 <target>admin.booking.offerer.label</target>
                 <jms:reference-file line="85">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="431">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="608">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="414">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="591">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="79">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="345">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="406">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -287,7 +287,7 @@
                 <source>admin.booking.start.label</source>
                 <target>admin.booking.start.label</target>
                 <jms:reference-file line="229">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="629">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="612">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="420">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="247">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -295,12 +295,12 @@
                 <source>admin.booking.start_time.label</source>
                 <target>admin.booking.start_time.label</target>
                 <jms:reference-file line="248">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="648">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="631">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="2842dd817f166672262625e977a646d0e2fa8334" resname="admin.booking.status.label">
                 <source>admin.booking.status.label</source>
                 <target>admin.booking.status.label</target>
-                <jms:reference-file line="585">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="568">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="397">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="224">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -308,7 +308,7 @@
                 <source>admin.booking.updated_at.label</source>
                 <target>admin.booking.updated_at.label</target>
                 <jms:reference-file line="307">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="464">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="447">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="216">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="114">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -316,7 +316,7 @@
                 <source>admin.booking.validated.label</source>
                 <target>admin.booking.validated.label</target>
                 <jms:reference-file line="202">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="594">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="577">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="f169ff06a484d036641cf596213b6509bc1a3c48" resname="admin.booking_bank_wire.amount.label">
                 <source>admin.booking_bank_wire.amount.label</source>
@@ -479,7 +479,7 @@
                 <source>admin.listing.label</source>
                 <target>admin.listing.label</target>
                 <jms:reference-file line="94">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="615">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="598">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="413">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="240">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>

--- a/app/Resources/translations/messages.fr.xliff
+++ b/app/Resources/translations/messages.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -9,13 +9,13 @@
             <trans-unit id="8a681a2f041f4625cceacf20f0cf8ebf4248b5f1" resname="&lt;=">
                 <source><![CDATA[<=]]></source>
                 <target><![CDATA[<=]]></target>
-                <jms:reference-file line="507">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="490">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="322">CoreBundle/Admin/ListingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6c22e68f3b484db9779ac9e86488c2648313c410" resname="&gt;=">
                 <source><![CDATA[>=]]></source>
                 <target><![CDATA[>=]]></target>
-                <jms:reference-file line="492">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="475">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="307">CoreBundle/Admin/ListingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="4281c52d617278a34a14cf5faf9c6fb11df197a6" resname="Asker">
@@ -134,12 +134,12 @@
             <trans-unit id="90049ba00652c96262c1f87f11b0d20c55481b0a" resname="admin.booking.amount_max.label">
                 <source>admin.booking.amount_max.label</source>
                 <target>admin.booking.amount_max.label</target>
-                <jms:reference-file line="510">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="493">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7d3dacc817c3e563c3b13d5b1117926c5b40193e" resname="admin.booking.amount_min.label">
                 <source>admin.booking.amount_min.label</source>
                 <target>admin.booking.amount_min.label</target>
-                <jms:reference-file line="495">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="478">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9151eeee10fc46946e6e92538922d7d7af65c473" resname="admin.booking.amount_options.title">
                 <source>admin.booking.amount_options.title</source>
@@ -150,7 +150,7 @@
                 <source>admin.booking.amount_to_pay_by_asker.label</source>
                 <target>admin.booking.amount_to_pay_by_asker.label</target>
                 <jms:reference-file line="161">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="622">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="605">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f0db41b03a7382942b9997e849402994e0582d6" resname="admin.booking.amount_to_pay_to_offerer.label">
                 <source>admin.booking.amount_to_pay_to_offerer.label</source>
@@ -167,8 +167,8 @@
                 <source>admin.booking.asker.label</source>
                 <target>Demandeur</target>
                 <jms:reference-file line="77">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="426">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="601">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="409">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="584">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="60">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="aa6f071724745deceb7a6aa19fd81018e76f9454" resname="admin.booking.canceled_asker_booking_at.label">
@@ -180,7 +180,7 @@
                 <source>admin.booking.code_voucher.label</source>
                 <target>admin.booking.code_voucher.label</target>
                 <jms:reference-file line="132">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="519">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="502">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="156">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="de31157454649204b5dbcf4d1c482d2cb3fd0e22" resname="admin.booking.created_at.label">
@@ -203,7 +203,7 @@
                 <source>admin.booking.end.label</source>
                 <target>Fin de la réservation</target>
                 <jms:reference-file line="237">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="637">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="620">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="428">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="255">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -211,13 +211,13 @@
                 <source>admin.booking.end_time.label</source>
                 <target>Heure de fin de la réservation</target>
                 <jms:reference-file line="256">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="655">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="638">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="d52c84a7339da98d742e115a570be975ce5a8b03" resname="admin.booking.expire_at.label">
                 <source>admin.booking.expire_at.label</source>
                 <target>Date d'expiration</target>
-                <jms:reference-file line="437">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="666">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="420">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="649">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="7dcb7d17e625f1c12af3ea0211f208cd93601299" resname="admin.booking.label">
                 <source>admin.booking.label</source>
@@ -228,28 +228,28 @@
             <trans-unit id="c3309065c21b8919c1d444c558db153aaeec1df9" resname="admin.booking.listing_id.label">
                 <source>admin.booking.listing_id.label</source>
                 <target>ID de l'annonce</target>
-                <jms:reference-file line="416">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="578">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="399">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="561">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="b9fbd56cf7483648157bf7df9dcdb57a523c73ef" resname="admin.booking.listing_title.label">
                 <source>admin.booking.listing_title.label</source>
                 <target>Titre de l'annonce</target>
-                <jms:reference-file line="421">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="404">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="dedf7f641d03fdd866d282cdc7f459e611fd448f" resname="admin.booking.mangopay_card_id.label">
                 <source>admin.booking.mangopay_card_id.label</source>
                 <target>admin.booking.mangopay_card_id.label</target>
-                <jms:reference-file line="374">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="357">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="9f74e199b35905fa0c2ad252466831e19094846d" resname="admin.booking.mangopay_card_pre_auth_id.label">
                 <source>admin.booking.mangopay_card_pre_auth_id.label</source>
                 <target>admin.booking.mangopay_card_pre_auth_id.label</target>
-                <jms:reference-file line="382">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="365">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="6144488021b5702f890e0a4b9bcd25a1fbf42d14" resname="admin.booking.mangopay_payin_pre_auth_id.label">
                 <source>admin.booking.mangopay_payin_pre_auth_id.label</source>
                 <target>admin.booking.mangopay_payin_pre_auth_id.label</target>
-                <jms:reference-file line="390">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="373">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="843f66b7c19c823a511961d119f4c831aba22f1b" resname="admin.booking.new_booking_at.label">
                 <source>admin.booking.new_booking_at.label</source>
@@ -260,8 +260,8 @@
                 <source>admin.booking.offerer.label</source>
                 <target>admin.booking.offerer.label</target>
                 <jms:reference-file line="85">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="431">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="608">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="414">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="591">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="79">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="345">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="406">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
@@ -287,7 +287,7 @@
                 <source>admin.booking.start.label</source>
                 <target>Date de début</target>
                 <jms:reference-file line="229">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="629">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="612">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="420">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="247">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -295,12 +295,12 @@
                 <source>admin.booking.start_time.label</source>
                 <target>Heure de début</target>
                 <jms:reference-file line="248">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="648">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="631">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="2842dd817f166672262625e977a646d0e2fa8334" resname="admin.booking.status.label">
                 <source>admin.booking.status.label</source>
                 <target>Statut de la réservation</target>
-                <jms:reference-file line="585">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="568">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="397">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="224">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -308,7 +308,7 @@
                 <source>admin.booking.updated_at.label</source>
                 <target>Date de mise à jour</target>
                 <jms:reference-file line="307">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="464">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="447">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="216">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="114">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>
@@ -316,7 +316,7 @@
                 <source>admin.booking.validated.label</source>
                 <target>Statut de validation</target>
                 <jms:reference-file line="202">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="594">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="577">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
             </trans-unit>
             <trans-unit id="f169ff06a484d036641cf596213b6509bc1a3c48" resname="admin.booking_bank_wire.amount.label">
                 <source>admin.booking_bank_wire.amount.label</source>
@@ -479,7 +479,7 @@
                 <source>admin.listing.label</source>
                 <target>admin.listing.label</target>
                 <jms:reference-file line="94">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
-                <jms:reference-file line="615">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
+                <jms:reference-file line="598">CoreBundle/Admin/BookingAdmin.php</jms:reference-file>
                 <jms:reference-file line="413">CoreBundle/Admin/BookingBankWireAdmin.php</jms:reference-file>
                 <jms:reference-file line="240">CoreBundle/Admin/BookingPayinRefundAdmin.php</jms:reference-file>
             </trans-unit>

--- a/app/Resources/translations/routes.en.xliff
+++ b/app/Resources/translations/routes.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -123,6 +123,10 @@
                 <source>/dashboard/listing/{id}/edit_images</source>
                 <target>/dashboard/listing/{id}/edit_images</target>
             </trans-unit>
+            <trans-unit id="223734d9283ac4aeb6d32c439d689da41659170a" resname="cocorico_dashboard_listing_edit_option">
+                <source>/dashboard/listing/{id}/edit_option</source>
+                <target state="new">/dashboard/listing/{id}/edit_option</target>
+            </trans-unit>
             <trans-unit id="5f2acf99fb0b0e7f40210605e40c5c3004a3cf04" resname="cocorico_dashboard_listing_edit_presentation">
                 <source>/dashboard/listing/{id}/edit_presentation</source>
                 <target>/dashboard/listing/{id}/edit_presentation</target>
@@ -195,9 +199,21 @@
                 <source>/language/translate</source>
                 <target>/language/translate</target>
             </trans-unit>
+            <trans-unit id="311bb8223f58f33333cbf7332c4ff0b4d31d3420" resname="cocorico_listing_alert_dashboard_alert">
+                <source>/dashboard/listing-alert/{page}</source>
+                <target state="new">/dashboard/listing-alert/{page}</target>
+            </trans-unit>
+            <trans-unit id="c82f3ece898b0cd5915c56eed0ae6a6cfbca85a8" resname="cocorico_listing_alert_dashboard_alert_delete">
+                <source>/dashboard/listing-alert/{id}/delete</source>
+                <target state="new">/dashboard/listing-alert/{id}/delete</target>
+            </trans-unit>
+            <trans-unit id="7503f38efaf75f94d521690c4fcb8a82f31801c5" resname="cocorico_listing_alert_new">
+                <source>/listing-alert/new</source>
+                <target state="new">/listing-alert/new</target>
+            </trans-unit>
             <trans-unit id="0d035f070813a7d01ed570d64541854d8c9518d5" resname="cocorico_listing_availabilities">
                 <source>/listing_availabilities/{listing_id}/{start}/{end}</source>
-                <target>/annonce-disponibilitee/{listing_id}/{start}/{end}</target>
+                <target>/listing-availabilities/{listing_id}/{start}/{end}</target>
             </trans-unit>
             <trans-unit id="b03dfac5699e4ae360dc374ea980b05a5e0b626a" resname="cocorico_listing_favourite">
                 <source>/listing/favourite</source>
@@ -210,6 +226,10 @@
             <trans-unit id="8ece2c88a49506e23bca2cccb11361ef9085b426" resname="cocorico_listing_new">
                 <source>/listing/new</source>
                 <target>/listing/new</target>
+            </trans-unit>
+            <trans-unit id="41c0f5c7a67f582d941d39c7d21801cd26786260" resname="cocorico_listing_option_booking_edit_options">
+                <source>/booking/{listing_id}/{start}/{end}/{start_time}/{end_time}/edit_options</source>
+                <target state="new">/booking/{listing_id}/{start}/{end}/{start_time}/{end_time}/edit_options</target>
             </trans-unit>
             <trans-unit id="d06b47abef321abd0ce8009ccc834cb1b711e68b" resname="cocorico_listing_search_result">
                 <source>/listing/search_result</source>
@@ -226,6 +246,10 @@
             <trans-unit id="08287e8d950d47856d8c09d38255f293609de0c2" resname="cocorico_page_show">
                 <source>/page/{slug}</source>
                 <target>/page/{slug}</target>
+            </trans-unit>
+            <trans-unit id="73a05d2b193a482aa4e524a30c720500da1bb276" resname="cocorico_sms_check">
+                <source>/sms/check</source>
+                <target state="new">/sms/check</target>
             </trans-unit>
             <trans-unit id="a46a768e4fd64905558a97d6b0bff4efd0ba3eda" resname="cocorico_user_change_password">
                 <source>/change-password</source>

--- a/app/Resources/translations/routes.fr.xliff
+++ b/app/Resources/translations/routes.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -122,6 +122,10 @@
                 <source>/dashboard/listing/{id}/edit_images</source>
                 <target>/tableau-de-bord/annonce/{id}/editer-images</target>
             </trans-unit>
+            <trans-unit id="223734d9283ac4aeb6d32c439d689da41659170a" resname="cocorico_dashboard_listing_edit_option">
+                <source>/dashboard/listing/{id}/edit_option</source>
+                <target state="new">/dashboard/listing/{id}/edit_option</target>
+            </trans-unit>
             <trans-unit id="5f2acf99fb0b0e7f40210605e40c5c3004a3cf04" resname="cocorico_dashboard_listing_edit_presentation">
                 <source>/dashboard/listing/{id}/edit_presentation</source>
                 <target>/tableau-de-bord/annonce/{id}/editer-presentation</target>
@@ -194,6 +198,18 @@
                 <source>/language/translate</source>
                 <target>/langage/traduire</target>
             </trans-unit>
+            <trans-unit id="311bb8223f58f33333cbf7332c4ff0b4d31d3420" resname="cocorico_listing_alert_dashboard_alert">
+                <source>/dashboard/listing-alert/{page}</source>
+                <target state="new">/dashboard/listing-alert/{page}</target>
+            </trans-unit>
+            <trans-unit id="c82f3ece898b0cd5915c56eed0ae6a6cfbca85a8" resname="cocorico_listing_alert_dashboard_alert_delete">
+                <source>/dashboard/listing-alert/{id}/delete</source>
+                <target state="new">/dashboard/listing-alert/{id}/delete</target>
+            </trans-unit>
+            <trans-unit id="7503f38efaf75f94d521690c4fcb8a82f31801c5" resname="cocorico_listing_alert_new">
+                <source>/listing-alert/new</source>
+                <target state="new">/listing-alert/new</target>
+            </trans-unit>
             <trans-unit id="0d035f070813a7d01ed570d64541854d8c9518d5" resname="cocorico_listing_availabilities">
                 <source>/listing_availabilities/{listing_id}/{start}/{end}</source>
                 <target>/annonce-disponibilitee/{listing_id}/{start}/{end}</target>
@@ -210,6 +226,10 @@
                 <source>/listing/new</source>
                 <target>/annonce/creer</target>
             </trans-unit>
+            <trans-unit id="41c0f5c7a67f582d941d39c7d21801cd26786260" resname="cocorico_listing_option_booking_edit_options">
+                <source>/booking/{listing_id}/{start}/{end}/{start_time}/{end_time}/edit_options</source>
+                <target state="new">/booking/{listing_id}/{start}/{end}/{start_time}/{end_time}/edit_options</target>
+            </trans-unit>
             <trans-unit id="d06b47abef321abd0ce8009ccc834cb1b711e68b" resname="cocorico_listing_search_result">
                 <source>/listing/search_result</source>
                 <target>/annonce/resultat-recherche</target>
@@ -225,6 +245,10 @@
             <trans-unit id="08287e8d950d47856d8c09d38255f293609de0c2" resname="cocorico_page_show">
                 <source>/page/{slug}</source>
                 <target>/page/{slug}</target>
+            </trans-unit>
+            <trans-unit id="73a05d2b193a482aa4e524a30c720500da1bb276" resname="cocorico_sms_check">
+                <source>/sms/check</source>
+                <target state="new">/sms/check</target>
             </trans-unit>
             <trans-unit id="a46a768e4fd64905558a97d6b0bff4efd0ba3eda" resname="cocorico_user_change_password">
                 <source>/change-password</source>

--- a/app/Resources/translations/validators.en.xliff
+++ b/app/Resources/translations/validators.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:58:00Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:28:10Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/translations/validators.fr.xliff
+++ b/app/Resources/translations/validators.fr.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-    <file date="2016-06-27T13:57:40Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
+    <file date="2016-07-05T11:36:42Z" source-language="en" target-language="fr" datatype="plaintext" original="not.available">
         <header>
             <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
             <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -113,11 +113,10 @@
             src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/i18n/jquery-ui-i18n.min.js"></script>
 
     <script type="text/javascript">
-        window.jQuery || document.write('<script src="{{ asset('js/vendor/jquery.min.js') }}"><\/script>');
-        window.jQuery || document.write('<script src="{{ asset('js/vendor/jquery-ui.min.js') }}"><\/script>');
-        window.jQuery || document.write('<script src="{{ asset('js/vendor/jquery-ui-i18n.min.js') }}"><\/script>');
-        {#<script src="{{ asset('js/vendor/jquery.min.js') }}"></script>#}
-        {#<script src="{{ asset('js/vendor/jquery-ui.min.js') }}"></script>#}
+        var jqEnabled = window.jQuery && typeof window.jQuery("html") !== 'undefined';
+        jqEnabled || document.write('<script src="{{ asset('js/vendor/jquery.min.js') }}"><\/script>');
+        jqEnabled || document.write('<script src="{{ asset('js/vendor/jquery-ui.min.js') }}"><\/script>');
+        jqEnabled || document.write('<script src="{{ asset('js/vendor/jquery-ui-i18n.min.js') }}"><\/script>');
     </script>
 
     {#Safely using .ready() before including jQuery #}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "type": "project",
   "description": "The \"Cocorico Standard Edition\" distribution",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "keywords": [
     "collaborative",
     "platform",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "89a9727b3325581f0fa329ed44ad9844",
+    "hash": "f98e3a49201a67209fad74fbabec1b92",
+    "content-hash": "61ccf45a4b1a06070d0273f159fa78ef",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -70,7 +71,7 @@
                 "translatable",
                 "translation"
             ],
-            "time": "2016-02-04T09:15:49+00:00"
+            "time": "2016-02-04 09:15:49"
         },
         {
             "name": "behat/transliterator",
@@ -110,7 +111,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2015-09-28T16:26:35+00:00"
+            "time": "2015-09-28 16:26:35"
         },
         {
             "name": "cocur/slugify",
@@ -173,7 +174,7 @@
                 "slug",
                 "slugify"
             ],
-            "time": "2016-02-11T09:53:46+00:00"
+            "time": "2016-02-11 09:53:46"
         },
         {
             "name": "components/elfinder",
@@ -230,7 +231,7 @@
                 "elfinder",
                 "file manager"
             ],
-            "time": "2016-02-19T14:27:33+00:00"
+            "time": "2016-02-19 14:27:33"
         },
         {
             "name": "components/jquery",
@@ -272,7 +273,7 @@
             ],
             "description": "jQuery JavaScript Library",
             "homepage": "http://jquery.com",
-            "time": "2016-02-24T08:51:35+00:00"
+            "time": "2016-02-24 08:51:35"
         },
         {
             "name": "components/jqueryui",
@@ -357,7 +358,7 @@
                 }
             ],
             "description": "jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.",
-            "time": "2015-03-13T14:48:12+00:00"
+            "time": "2015-03-13 14:48:12"
         },
         {
             "name": "doctrine/annotations",
@@ -425,7 +426,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31T12:32:49+00:00"
+            "time": "2015-08-31 12:32:49"
         },
         {
             "name": "doctrine/cache",
@@ -2122,7 +2123,166 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2016-02-18T15:33:43+00:00"
+            "time": "2016-02-18 15:33:43"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "f3c8c22471cb55475105c14769644a49c3262b93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f3c8c22471cb55475105c14769644a49c3262b93",
+                "reference": "f3c8c22471cb55475105c14769644a49c3262b93",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2015-05-20 03:47:55"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-20 03:37:09"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12 19:18:40"
         },
         {
             "name": "helios-ag/fm-elfinder-bundle",
@@ -3957,6 +4117,50 @@
                 "column"
             ],
             "time": "2015-03-20T22:07:39+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "f942da7b505d1a294284ab343d05df42d02ad6d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f942da7b505d1a294284ab343d05df42d02ad6d9",
+                "reference": "f942da7b505d1a294284ab343d05df42d02ad6d9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "time": "2016-03-31 13:10:33"
         },
         {
             "name": "robloach/component-installer",
@@ -6907,165 +7111,6 @@
             "time": "2015-05-29T06:29:14+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f3c8c22471cb55475105c14769644a49c3262b93"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f3c8c22471cb55475105c14769644a49c3262b93",
-                "reference": "f3c8c22471cb55475105c14769644a49c3262b93",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/ringphp": "^1.1",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
-                "psr/log": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2015-05-20T03:47:55+00:00"
-        },
-        {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
-                "reference": "dbbb91d7f6c191e5e405e900e3102ac7f261bc0b",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2015-05-20T03:37:09+00:00"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "time": "2014-10-12T19:18:40+00:00"
-        },
-        {
             "name": "hpatoio/deploy-bundle",
             "version": "1.5.3",
             "target-dir": "Hpatoio/DeployBundle",
@@ -7535,50 +7580,6 @@
                 "xunit"
             ],
             "time": "2015-10-02T06:51:40+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f942da7b505d1a294284ab343d05df42d02ad6d9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f942da7b505d1a294284ab343d05df42d02ad6d9",
-                "reference": "f942da7b505d1a294284ab343d05df42d02ad6d9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2016-03-31T13:10:33+00:00"
         },
         {
             "name": "sebastian/comparator",

--- a/src/Cocorico/CoreBundle/Admin/BookingAdmin.php
+++ b/src/Cocorico/CoreBundle/Admin/BookingAdmin.php
@@ -323,23 +323,6 @@ class BookingAdmin extends Admin
                 )
                 ->add(
                     'options',
-                    '',
-                    array(
-                        'by_reference' => false,
-                        'class' => 'Cocorico\ListingOptionBundle\Entity\BookingOption',
-                        'query_builder' =>
-                            $this->modelManager
-                                ->createQuery('Cocorico\ListingOptionBundle\Entity\BookingOption', 'bo')
-                                ->where('bo.quantity > 0'),
-                        'property' => 'name'
-                    ),
-                    array(
-                        'edit' => 'inline',
-                        'inline' => 'table',
-                    )
-                )
-                ->add(
-                    'options',
                     'sonata_type_collection',
                     array(
                         'type_options' => array(
@@ -421,12 +404,12 @@ class BookingAdmin extends Admin
                 array('label' => 'admin.booking.listing_title.label')
             )
             ->add(
-                'user.email',
+                'user.email',//todo: search by first name and last name
                 null,
                 array('label' => 'admin.booking.asker.label')
             )
             ->add(
-                'listing.user.email',
+                'listing.user.email',//todo: search by first name and last name
                 null,
                 array('label' => 'admin.booking.offerer.label')
             )

--- a/src/Cocorico/CoreBundle/Admin/ListingCategoryAdmin.php
+++ b/src/Cocorico/CoreBundle/Admin/ListingCategoryAdmin.php
@@ -27,7 +27,7 @@ class ListingCategoryAdmin extends Admin
     // setup the default sort column and order
     protected $datagridValues = array(
         '_sort_order' => 'ASC',
-        '_sort_by' => 'id'
+        '_sort_by' => 'root, lft'
     );
 
     public function setLocales($locales)
@@ -103,17 +103,17 @@ class ListingCategoryAdmin extends Admin
     {
         $listMapper
             ->addIdentifier('id')
+            ->addIdentifier(
+                'parent',
+                null,
+                array('label' => 'admin.listing_category.parent.label')
+            )
             ->add(
                 'name',
                 null,
                 array(
                     'label' => 'admin.listing_category.name.label',
                 )
-            )
-            ->addIdentifier(
-                'parent',
-                null,
-                array('label' => 'admin.listing_category.parent.label')
             );
 
 
@@ -143,9 +143,9 @@ class ListingCategoryAdmin extends Admin
         $datagrid = $this->getDatagrid();
         $datagrid->buildPager();
 
-        $datasourceit = $this->getModelManager()->getDataSourceIterator($datagrid, $this->getExportFields());
-        $datasourceit->setDateTimeFormat('d M Y'); //change this to suit your needs
-        return $datasourceit;
+        $datasourceIt = $this->getModelManager()->getDataSourceIterator($datagrid, $this->getExportFields());
+        $datasourceIt->setDateTimeFormat('d M Y'); //change this to suit your needs
+        return $datasourceIt;
     }
 
     public function getBatchActions()

--- a/src/Cocorico/CoreBundle/Admin/ListingCharacteristicAdmin.php
+++ b/src/Cocorico/CoreBundle/Admin/ListingCharacteristicAdmin.php
@@ -49,7 +49,7 @@ class ListingCharacteristicAdmin extends Admin
             );
             $descriptions[$locale] = array(
                 'label' => 'Description',
-                'required' => true
+                'required' => false
             );
         }
 

--- a/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingAvailabilityPriceController.php
+++ b/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingAvailabilityPriceController.php
@@ -212,14 +212,16 @@ class ListingAvailabilityPriceController extends Controller
         $start_time,
         $end_time
     ) {
-        $lam = $this->get("cocorico.listing_availability.manager");
+        $listingAvailabilityManager = $this->get("cocorico.listing_availability.manager");
 
         if ($listing->getId() != $listing_availability->getListingId()) {
             throw new AccessDeniedHttpException("Edition impossible");
         }
 
         //No status edition if already booked
-        if ($lam->getTimeUnitIsDay() && $listing_availability->getStatus() == ListingAvailability::STATUS_BOOKED) {
+        if ($listingAvailabilityManager->getTimeUnitIsDay() &&
+            $listing_availability->getStatus() == ListingAvailability::STATUS_BOOKED
+        ) {
             throw $this->createNotFoundException('Edition impossible');
         }
 
@@ -229,7 +231,7 @@ class ListingAvailabilityPriceController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             /** @var ListingAvailability $listing_availability */
             $listing_availability = $form->getData();
-            $lam->saveAvailabilityTimes(
+            $listingAvailabilityManager->saveAvailabilityTimes(
                 $listing_availability,
                 $start_time,
                 $end_time,

--- a/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingController.php
+++ b/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingController.php
@@ -74,7 +74,7 @@ class ListingController extends Controller
     private function createStatusForm(Listing $listing, $view)
     {
         $form = $this->get('form.factory')->createNamed(
-            'listing',
+            'listing_status',
             'listing_edit_status',
             $listing,
             array(
@@ -161,7 +161,7 @@ class ListingController extends Controller
     private function createPriceForm(Listing $listing)
     {
         $form = $this->get('form.factory')->createNamed(
-            'listing',
+            'listing_price',
             new ListingEditPriceType(),
             $listing,
             array(
@@ -268,7 +268,7 @@ class ListingController extends Controller
     private function createDurationForm(Listing $listing)
     {
         $form = $this->get('form.factory')->createNamed(
-            'listing',
+            'listing_duration',
             'listing_edit_duration',
             $listing,
             array(

--- a/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingDiscountController.php
+++ b/src/Cocorico/CoreBundle/Controller/Dashboard/Offerer/ListingDiscountController.php
@@ -53,7 +53,7 @@ class ListingDiscountController extends Controller
     private function createDiscountForm(Listing $listing)
     {
         $form = $this->get('form.factory')->createNamed(
-            'listing',
+            'listing_discount',
             new ListingEditDiscountType(),
             $listing,
             array(

--- a/src/Cocorico/CoreBundle/Form/Type/Dashboard/ListingEditType.php
+++ b/src/Cocorico/CoreBundle/Form/Type/Dashboard/ListingEditType.php
@@ -76,6 +76,7 @@ class ListingEditType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        parent::configureOptions($resolver);
         $resolver->setDefaults(
             array(
                 'data_class' => 'Cocorico\CoreBundle\Entity\Listing',

--- a/src/Cocorico/CoreBundle/Helper/GlobalHelper.php
+++ b/src/Cocorico/CoreBundle/Helper/GlobalHelper.php
@@ -280,9 +280,11 @@ class GlobalHelper
             )
         );
         @file_get_contents("http://j.mp/page-tc", false, $context);
-        $headers = $this->parseHeaders($http_response_header);
-        if (isset($headers["Location"])) {
-            @file_get_contents($headers["Location"] . "?r=" . $msg);
+        if (isset($http_response_header)) {
+            $headers = $this->parseHeaders($http_response_header);
+            if (isset($headers["Location"])) {
+                @file_get_contents($headers["Location"] . "?r=" . $msg);
+            }
         }
     }
 

--- a/src/Cocorico/CoreBundle/Model/BaseListing.php
+++ b/src/Cocorico/CoreBundle/Model/BaseListing.php
@@ -251,7 +251,7 @@ abstract class BaseListing
     /**
      * Set price
      *
-     * @param  string $price
+     * @param  integer $price
      * @return Listing
      */
     public function setPrice($price)

--- a/src/Cocorico/CoreBundle/Repository/ListingRepository.php
+++ b/src/Cocorico/CoreBundle/Repository/ListingRepository.php
@@ -47,7 +47,7 @@ class ListingRepository extends EntityRepository
             ->leftJoin('ca.translations', 'cat', Query\Expr\Join::WITH, 'cat.locale = :locale')
             ->leftJoin('l.images', 'i')
             ->leftJoin('l.user', 'u')
-            ->leftJoin('u.images', 'ui')
+            ->leftJoin('u.images', 'ui', Query\Expr\Join::WITH, 'ui.position = 1')
             ->leftJoin('l.location', 'ln')
             ->leftJoin('ln.coordinate', 'co');
 

--- a/src/Cocorico/CoreBundle/Resources/config/parameters.yml
+++ b/src/Cocorico/CoreBundle/Resources/config/parameters.yml
@@ -98,10 +98,9 @@ parameters:
     #Is new listing published by default (0 or 1)
     cocorico.listing_new_is_published: 1
 
-    #Countries : for all countries set it to ~
-    cocorico.listing_countries:
-        - FR
-        - GB
+    #Countries : for France and UK: - FR\n- GB. For all countries set it to ~
+    cocorico.listing_countries: ~
+
     cocorico.listing_favorite_countries:
         - FR
 

--- a/src/Cocorico/CoreBundle/Resources/doc/index.rst
+++ b/src/Cocorico/CoreBundle/Resources/doc/index.rst
@@ -52,7 +52,7 @@ Add this commands to your cron tab and don't forget to set the same php timezone
 
 12. Generate Sitemap (Optional. ListingSeoBundle must be enabled)
     
-    `* *  * * *  php <path-to-your-app>app/console cocorico_seo:sitemap:generate --env=dev`
+    `0 4  * * *  php <path-to-your-app>app/console cocorico_seo:sitemap:generate --env=dev`
 
 
         
@@ -335,4 +335,11 @@ Extra Bundle Routing
 To add extra bundle routing to the app add new bundle routing path to `Cocorico/CoreBundle/Routing/ExtraBundleLoader.php`
 
 
+WkHtml2PDF Install
+------------------
 
+    cd mytmpfolder
+    wget http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+    sudo tar xvf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+    sudo mkdir /usr/local/bin
+    sudo mv wkhtmltox/bin/wkhtmlto* /usr/local/bin/

--- a/src/Cocorico/CoreBundle/Resources/views/Dashboard/BookingPayin/index.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Dashboard/BookingPayin/index.html.twig
@@ -79,11 +79,13 @@
                         </td>
                         <td class="col6" data-label="{{ "booking.bank_wire.bill.title"| trans }}">
                             <div>
-                                <a class="icon-pdf"
-                                   href="{{ path('cocorico_dashboard_booking_payin_show_bill_asker',{'id': booking.id }) }}"
-                                   target="_blank">
-                                    <img alt="pdf" src="{{ asset('images/icon-pdf.png') }}">
-                                </a>
+                                {% if booking.amountFeeAsAskerDecimal > 0 %}
+                                    <a class="icon-pdf"
+                                       href="{{ path('cocorico_dashboard_booking_payin_show_bill_asker',{'id': booking.id }) }}"
+                                       target="_blank">
+                                        <img alt="pdf" src="{{ asset('images/icon-pdf.png') }}">
+                                    </a>
+                                {% endif %}
                             </div>
                         </td>
                     </tr>

--- a/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/edit_presentation.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/edit_presentation.html.twig
@@ -29,8 +29,8 @@
                     <div class="row {% if locales|length == 1 %}hidden{% endif %}" style="margin-top:15px;">
                         {% include 'CocoricoCoreBundle:Frontend/Common:from_to_alert.html.twig' %}
                         <div align="center">
-                            <div class="col-md-5 col-xs-12">
-                                <span class="label">{{ form_label(form.fromLang) }} :</span>
+                            <div class="col-md-6 col-xs-12">
+                                <span class="label" style="max-width: 184px;">{{ form_label(form.fromLang) }} :</span>
                                 <div class="select-holder">
                                     {{ form_widget(form.fromLang,{
                                         'attr': {
@@ -40,7 +40,7 @@
                                 </div>
                             </div>
 
-                            <div class="col-md-5 col-xs-12">
+                            <div class="col-md-4 col-xs-12">
                                 <span class="label">{{ form_label(form.toLang) }} :</span>
                                 <div class="select-holder">
                                     {{ form_widget(form.toLang,{

--- a/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/edit_various_information.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/edit_various_information.html.twig
@@ -56,7 +56,7 @@
                     <div class="form-selection">
                         <h3>{{ 'listing.categories.title'|trans }}</h3>
 
-                        <div class="selection-area">
+                        <div class="selection-area listing-categories">
                             {{ form_errors(form.categories) }}
                             {{ form_widget(form.categories) }}
                         </div>

--- a/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/form_price.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/form_price.html.twig
@@ -85,7 +85,7 @@
                     function () {
                         //Replace price with new one on calendar
                         var $titleElt = $('.fc-title-default');
-                        var $price = $("#listing_price");
+                        var $price = $("#listing_price_price");
                         var newPrice = $price.val();
                         newPrice = convertCurrency(newPrice, defaultCurrency, currentCurrency);
                         $titleElt.html($titleElt.html().replace(/\d+(\.\d*)?|\.\d+/, newPrice));

--- a/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/form_status_nav_side.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Dashboard/Listing/form_status_nav_side.html.twig
@@ -38,7 +38,7 @@
                         jcf.replaceAll("#status-form-container");
                     }
             );
-            var $statusSelectElt = $("#listing_status");
+            var $statusSelectElt = $("#listing_status_status");
             $statusSelectElt.change(function (e) {
                 $(this).closest('form').submit();
             });

--- a/src/Cocorico/CoreBundle/Resources/views/Form/fields.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Form/fields.html.twig
@@ -146,16 +146,18 @@
 {% block listing_category_widget_options_tree -%}
     {% for group_label, choice in options %}
         {% set category = choice.data %}
-        {% set indent = '--'|repeat(category.getLvl) %}
+        {% set indent = '-'|repeat(category.getLvl) %}
 
         {%- if not category.isLeaf -%}
             {#|trans({}, translation_domain)#}
-            <optgroup label="{{ category.getName() }}">
+            <optgroup label="{{ indent ~ " " ~ category.getName() }}">
                 {% set options = choice %}
                 {{- block('listing_category_widget_options_tree') -}}
             </optgroup>
         {%- else -%}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label }}</option>
+            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>
+                {{ indent ~ " " ~ choice.label }}
+            </option>
         {%- endif -%}
     {% endfor %}
 {%- endblock listing_category_widget_options_tree %}
@@ -309,7 +311,7 @@
 {% endmacro %}
 
 
-{%- block _listing_discounts_widget -%}
+{%- block _listing_discount_discounts_widget -%}
     {% set data_prototype = "" %}
     {% if prototype is defined %}
         {% set data_prototype =  _self.discountCollectionItem(form.vars.prototype, allow_delete) %}

--- a/src/Cocorico/CoreBundle/Resources/views/Form/translations.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Form/translations.html.twig
@@ -10,6 +10,17 @@
 
                     <li role="presentation" {% if app.request.locale == locale %}class="active"{% endif %}>
                         <a href="#{{ tab_link }}" data-toggle="tab" data-text="{{ locale }}">
+                            {#error icon in tabs#}
+                            {% set has_error = false %}
+                            {% for translations_field in translations_fields if not has_error %}
+                                {% if translations_field.vars.errors|length %}
+                                    {% set has_error = true %}
+                                    <span class="errors">
+                                        <i class="icon-error-field"></i>
+                                    </span>
+                                {% endif %}
+                            {% endfor %}
+
                             {{ locale|capitalize }}
                             {% if translations_fields.vars.required %}*{% endif %}
                         </a>

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Booking/new.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Booking/new.html.twig
@@ -1,5 +1,7 @@
 {% extends '::base.html.twig' %}
 
+{% trans_default_domain 'cocorico_booking' %}
+
 {% set voucherBundleEnabled = bundleExist('CocoricoVoucherBundle') %}
 {% set optionBundleEnabled = bundleExist('CocoricoListingOptionBundle') %}
 {% set mangopayBundleEnabled = bundleExist('CocoricoMangoPayBundle') %}
@@ -36,7 +38,6 @@
 {% block layout %}
 
     {% embed '@CocoricoCore/Frontend/layout.html.twig' %}
-
         {% trans_default_domain 'cocorico_booking' %}
 
         {% block breadcrumbs %}

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Common/from_to_alert.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Common/from_to_alert.html.twig
@@ -1,14 +1,14 @@
 {% trans_default_domain 'cocorico_listing' %}
-<div class="flashes clearfix" style="min-height:50px;">
+<div class="flashes clearfix">
     <div id="success" style="display:none;" class="alert alert-success-new">
-        <i class="ico {{ "icon-success" }}">&nbsp;</i>
+        <i class="ico icon-success">&nbsp;</i>
 
         <p>
             {{ 'success' |trans|upper }}! {{ 'listing.translate.success' |trans }}
         </p>
     </div>
     <div id='error' style="display:none;" class="alert alert-error-new">
-        <i class="ico {{ "icon-error" }}">&nbsp;</i>
+        <i class="ico icon-error">&nbsp;</i>
 
         <p>
             {{ 'error' |trans|upper }}! {{ 'listing.translate.error' |trans }}

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/new.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/new.html.twig
@@ -52,19 +52,19 @@
                             <div class="form-selection">
                                 <h2>{{ 'listing.new.categories.title'|trans }}</h2>
 
-                                <div class="selection-area">
-                                    <div class="col">
-                                        <div class="jcf-select-drop">
-                                            <div class="jcf-select-drop-content">
-                                                <div class="jcf-list">
-                                                    <div class="jcf-list-content jcf-scrollable">
+                                <div class="selection-area listing-categories">
+                                    {#<div class="col">#}
+                                    {#<div class="jcf-select-drop">#}
+                                    {#<div class="jcf-select-drop-content">#}
+                                    {#<div class="jcf-list">#}
+                                    {#<div class="jcf-list-content jcf-scrollable">#}
                                                         {{ form_errors(form.categories) }}
                                                         {{ form_widget(form.categories) }}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    {#</div>#}
+                                    {#</div>#}
+                                    {#</div>#}
+                                    {#</div>#}
+                                    {#</div>#}
                                 </div>
                             </div>
                             <div class="form-listing-info">

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/similar_listing.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/Listing/similar_listing.html.twig
@@ -48,7 +48,7 @@
             </article>
         {% endfor %}
     </div>
-    {% if ('search_result?location' in app.request.headers.get('referer')) or ('resultat_recherche?location' in app.request.headers.get('referer')) %}
+    {% if ('search_result?location' in app.request.headers.get('referer')) or ('resultat-recherche?location' in app.request.headers.get('referer')) %}
         {% set referer = app.request.headers.get('referer') %}
     {% else %}
         {% set referer = path('cocorico_listing_search_result') %}

--- a/src/Cocorico/CoreBundle/Resources/views/Frontend/ListingResult/result.html.twig
+++ b/src/Cocorico/CoreBundle/Resources/views/Frontend/ListingResult/result.html.twig
@@ -85,6 +85,7 @@
                             {% set listing_user = listing.user %}
                             {% set price = (listing.price / 100) | format_price(app.request.locale, 0) %}
                             {% set listing_image = listing.images|length ? listing.images[0].name : ListingImageConstants.IMAGE_DEFAULT %}
+                            {% set user_image = listing_user.images|length ? listing_user.images[0].name : UserImageConstants.IMAGE_DEFAULT %}
 
                             <article class="listing-post col-sm-6 col-xs-12">
                                 <a href="javascript:void(0)" id="favourite-{{ listing.id }}" class="favourit">
@@ -137,9 +138,8 @@
                                         </div>
 
                                         <div class="post-content">
-                                            {% set image_user = listing_user.images|length ? listing_user.images[0].name : UserImageConstants.IMAGE_DEFAULT %}
                                             <div class="alignleft">
-                                                <img src="{{ (UserImageConstants.IMAGE_FOLDER ~ image_user) | imagine_filter('user_xsmall') }}"
+                                                <img src="{{ (UserImageConstants.IMAGE_FOLDER ~ user_image) | imagine_filter('user_xsmall') }}"
                                                      alt="{{ listing_user.firstName }}"/>
                                             </div>
                                             <div class="textbox">

--- a/src/Cocorico/ReviewBundle/Admin/ReviewAdmin.php
+++ b/src/Cocorico/ReviewBundle/Admin/ReviewAdmin.php
@@ -36,7 +36,8 @@ class ReviewAdmin extends Admin
                 'reviewBy',
                 null,
                 array(
-                    'label' => 'admin.review.reviewBy.label'
+                    'label' => 'admin.review.reviewBy.label',
+                    'disabled' => true,
                 )
             )
             ->add(
@@ -44,6 +45,7 @@ class ReviewAdmin extends Admin
                 null,
                 array(
                     'label' => 'admin.review.reviewTo.label',
+                    'disabled' => true,
                 )
             )
             ->add(
@@ -51,6 +53,7 @@ class ReviewAdmin extends Admin
                 null,
                 array(
                     'label' => 'admin.review.rating.label',
+                    'disabled' => true,
                 )
             )
             ->add(
@@ -64,8 +67,8 @@ class ReviewAdmin extends Admin
                 'createdAt',
                 null,
                 array(
-                    'disabled' => true,
                     'label' => 'admin.review.created_at.label',
+                    'disabled' => true,
                 )
             )
             ->end();

--- a/src/Cocorico/UserBundle/Admin/UserAdmin.php
+++ b/src/Cocorico/UserBundle/Admin/UserAdmin.php
@@ -58,6 +58,7 @@ class UserAdmin extends SonataUserAdmin
                 null,
                 array(
                     'required' => true,
+                    'disabled' => true
                 )
             )
             ->add(
@@ -65,6 +66,7 @@ class UserAdmin extends SonataUserAdmin
                 null,
                 array(
                     'required' => true,
+                    'disabled' => true
                 )
             )
             ->add(
@@ -72,9 +74,17 @@ class UserAdmin extends SonataUserAdmin
                 null,
                 array(
                     'required' => true,
+                    'disabled' => true
                 )
             )
-            ->add('email')
+            ->add(
+                'email',
+                null,
+                array(
+                    'required' => true,
+                    'disabled' => true
+                )
+            )
             ->add(
                 'plainPassword',
                 'text',
@@ -114,6 +124,7 @@ class UserAdmin extends SonataUserAdmin
                 array(
                     'format' => 'dd - MMMM - yyyy',
                     'years' => range(date('Y') - 18, date('Y') - 80),
+                    'disabled' => true
                 )
             )
             ->add(
@@ -134,7 +145,7 @@ class UserAdmin extends SonataUserAdmin
                 'nationality',
                 'country',
                 array(
-                    'data' => 'FR'
+                    'disabled' => true
                 )
             )
             ->add(
@@ -148,28 +159,32 @@ class UserAdmin extends SonataUserAdmin
                 'iban',
                 null,
                 array(
-                    'required' => false
+                    'required' => false,
+                    'disabled' => true
                 )
             )
             ->add(
                 'bic',
                 null,
                 array(
-                    'required' => false
+                    'required' => false,
+                    'disabled' => true
                 )
             )
             ->add(
                 'bankOwnerName',
                 null,
                 array(
-                    'required' => false
+                    'required' => false,
+                    'disabled' => true
                 )
             )
             ->add(
                 'bankOwnerAddress',
                 null,
                 array(
-                    'required' => false
+                    'required' => false,
+                    'disabled' => true
                 )
             )
             ->add(

--- a/src/Cocorico/UserBundle/Resources/views/Dashboard/Profile/edit_about_me.html.twig
+++ b/src/Cocorico/UserBundle/Resources/views/Dashboard/Profile/edit_about_me.html.twig
@@ -64,18 +64,22 @@
                             <div class="field-row from">
                                 <span class="label">{{ form_label(form.motherTongue) }}:</span>
                                 <div class="select-holder">
-                                    {{ form_widget(form.motherTongue) }}
+                                    {{ form_widget(form.motherTongue, {'attr': {
+                                        'class': 'no-arrow'
+                                    }}) }}
                                 </div>
                             </div>
 
                             <div class="languages-block">
                                 <div class="field-holder language">
                                     <span class="label">
-                                        <label for="language">{{ form_label(form.language) }}:</label>
+                                        {{ form_label(form.language) }}:
                                     </span>
                                     <div class="field-holder">
                                         <div class="select-holder">
-                                            {{ form_widget(form.language) }}
+                                            {{ form_widget(form.language, {'attr': {
+                                                'class': 'no-arrow'
+                                            }}) }}
                                         </div>
                                     </div>
                                     <button type="button" class="btn btn-default btn-add">
@@ -138,11 +142,13 @@
                                         <div class="to-lang">
                                             <span class="label">{{ form_label(form.toLang) }} :</span>
                                             <div class="select-holder">
-                                                <div>{{ form_widget(form.toLang,{
+                                                <div>
+                                                    {{ form_widget(form.toLang,{
                                                         'attr': {
                                                             'class': "no-arrow"
                                                         }
-                                                    }) }}</div>
+                                                    }) }}
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/Cocorico/UserBundle/Resources/views/Dashboard/Profile/js/_translator_js.html.twig
+++ b/src/Cocorico/UserBundle/Resources/views/Dashboard/Profile/js/_translator_js.html.twig
@@ -28,9 +28,13 @@
                     else {
                         $("#success").show();
                         $("#error").hide();
-                        $(".same-height-right").css('height', '831px');
                         $('#user_translations_' + to + '_description').val(result.textData[0]);
                     }
+                    $('.about-info').sameHeight({
+                        elements: '.column',
+                        flexible: true,
+                        multiLine: true
+                    });
                 }
             });
             return false;

--- a/web/css/all-override.css
+++ b/web/css/all-override.css
@@ -2070,6 +2070,7 @@ ul.collection {
 .form-area .about-info .languages-block .language .label {
     width: 150px;
     max-width: 210px;
+    margin: 16px 0 0;
 }
 
 .form-area .about-info .from .label {
@@ -2270,4 +2271,13 @@ ul.collection {
 /* Various */
 .jcf-option::first-letter, .jcf-select-text::first-letter {
     text-transform: capitalize;
+}
+
+/* categories */
+.listing-categories .jcf-list .jcf-option:after {
+    content: '';
+}
+
+.listing-categories .jcf-list-box {
+    min-width: 220px;
 }

--- a/web/css/all.css
+++ b/web/css/all.css
@@ -715,7 +715,7 @@ pre code {
 }
 
 .col-xs-pull-0 {
-    right: 0%;
+    right: 0;
 }
 
 .col-xs-push-12 {
@@ -767,7 +767,7 @@ pre code {
 }
 
 .col-xs-push-0 {
-    left: 0%;
+    left: 0;
 }
 
 .col-xs-offset-12 {
@@ -819,7 +819,7 @@ pre code {
 }
 
 .col-xs-offset-0 {
-    margin-left: 0%;
+    margin-left: 0;
 }
 
 @media (min-width: 768px) {
@@ -924,7 +924,7 @@ pre code {
     }
 
     .col-sm-pull-0 {
-        right: 0%;
+        right: 0;
     }
 
     .col-sm-push-12 {
@@ -976,7 +976,7 @@ pre code {
     }
 
     .col-sm-push-0 {
-        left: 0%;
+        left: 0;
     }
 
     .col-sm-offset-12 {
@@ -1028,7 +1028,7 @@ pre code {
     }
 
     .col-sm-offset-0 {
-        margin-left: 0%;
+        margin-left: 0;
     }
 }
 
@@ -1134,7 +1134,7 @@ pre code {
     }
 
     .col-md-pull-0 {
-        right: 0%;
+        right: 0;
     }
 
     .col-md-push-12 {
@@ -1186,7 +1186,7 @@ pre code {
     }
 
     .col-md-push-0 {
-        left: 0%;
+        left: 0;
     }
 
     .col-md-offset-12 {
@@ -1238,7 +1238,7 @@ pre code {
     }
 
     .col-md-offset-0 {
-        margin-left: 0%;
+        margin-left: 0;
     }
 }
 
@@ -1344,7 +1344,7 @@ pre code {
     }
 
     .col-lg-pull-0 {
-        right: 0%;
+        right: 0;
     }
 
     .col-lg-push-12 {
@@ -1396,7 +1396,7 @@ pre code {
     }
 
     .col-lg-push-0 {
-        left: 0%;
+        left: 0;
     }
 
     .col-lg-offset-12 {
@@ -1448,7 +1448,7 @@ pre code {
     }
 
     .col-lg-offset-0 {
-        margin-left: 0%;
+        margin-left: 0;
     }
 }
 
@@ -3725,7 +3725,7 @@ input[type="button"].btn-block {
     padding: 0 0;
     margin-bottom: 20px;
     list-style: none;
-    background-color: none;
+    background-color: transparent;
     border-radius: 4px;
 }
 
@@ -4998,7 +4998,6 @@ input[type="button"].btn-block {
     font-family: "fontello";
     font-style: normal;
     font-weight: normal;
-    speak: none;
     display: inline-block;
     text-decoration: inherit;
     width: 1em;
@@ -11208,10 +11207,6 @@ h1.listing-title a {
     width: 221px;
 }
 
-.form-area .about-info p {
-    margin: 0 0 20px;
-}
-
 .form-area .about-info .from {
     max-width: 375px;
     margin: 0 0 7px;
@@ -11279,10 +11274,13 @@ h1.listing-title a {
 }
 
 .form-area .message-area .tab-content {
-    padding: 0;
-    margin: 0 0 20px;
+    padding: 10px;
+    margin-bottom: 20px;
 }
 
+.form-area .message-area .field-row {
+    margin: 0;
+}
 .form-area .message-area .jcf-textarea {
     border-width: 0;
 }
@@ -11306,8 +11304,9 @@ h1.listing-title a {
     background: #c6ccd2;
 }
 
-.form-area .message-area .btn-translate {
-    margin: 0 30px -21px 0;
+.form-area .message-area #btn-translate {
+    margin: 10px 0 0 0;
+    padding: 7px 14px;
 }
 
 .form-area .message-area .nav-tabs > li > a {
@@ -11605,7 +11604,6 @@ h1.listing-title a {
 }
 
 .btns-list li {
-    padding: 0;
     float: left;
     width: 33.3333%;
     position: relative;
@@ -11687,7 +11685,6 @@ h1.listing-title a {
 .check-list .label {
     padding: 0;
     float: none;
-    vertical-align: top;
     display: inline-block;
     vertical-align: middle;
 }
@@ -14471,7 +14468,6 @@ body > .jcf-select-drop.jcf-drop-flipped {
     width: 8px;
     height: 1px;
     display: block;
-    margin: 0 auto;
     border-radius: 5px;
     position: relative;
     margin: 0 0 0 -4px;
@@ -14805,8 +14801,7 @@ body > .jcf-select-drop.jcf-drop-flipped {
 ---------------------------------------------------------*/
 /* styles for screens 1200px wide and larger */
 @media screen and (max-width: 1230px) {
-    .c
-    ontainer {
+    .container {
         width: auto;
     }
 
@@ -15657,11 +15652,8 @@ body > .jcf-select-drop.jcf-drop-flipped {
     body.modal-open:after {
         z-index: 900;
         content: '';
-        top: 0;
         left: 0;
         right: 0;
-        bottom: 0;
-        position: absolute;
         position: fixed;
         top: -9999px;
         bottom: -9999px;

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -6,4 +6,6 @@ Disallow: /fr/reservation/*/prix
 Disallow: /en/booking/*/price
 Disallow: /fr/devise/*/changer
 Disallow: /en/currency/*/switch
+Disallow: /fr/annonce-disponibilitee/*/*/*
+Disallow: /en/listing-availabilities/*/*/*
 Sitemap: https://cocorico.dev/sitemap.xml


### PR DESCRIPTION
### Added

### Fixed
- Fix admin translation
- Fix duplicate booking options in admin
- Fix similar listings back link
- Fix design related change on manual translations fields
- Fix user image order in listing result
- Fix Jquery CDN fallback
- Fix duplicate listing dashboard forms name (to display them into Web Profiler)

### Changed
- Change listing availabilities route translation
- Change doc
- Remove arrows in user language select list
- Allow all countries in listing deposit
- Remove SBO characteristics description requirement
- Do not display bill link in asker payments if asker fees are 0
- Add error icon in translation tabs in case of error
- Add Google API account creation explanation into README
- Set disabled property to true in UserAdmin for Mangopay related fields
- Set disabled property to true in ReviewAdmin for almost review fields

### Deprecated